### PR TITLE
Really requires PLY.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
     packages=['pytype', 'pytype/pyc', 'pytype/pytd', 'pytype/pytd/parse'],
     scripts=['scripts/pytype', 'scripts/pytd'],
     package_data={'pytype': ['pytd/builtins/*']},
-    requires=['ply (>=3.4)'],
+    install_requires=['ply>=3.4'],
 )


### PR DESCRIPTION
This forces installation of the PLY package when doing a `pip install`.

Also, what's constraint on the Python version ? This should probably be added to the `setup.py` too.