### PR TITLE
add pytype.pytd.builtins to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     packages=['pytype',
               'pytype/pyc',
               'pytype/pytd',
+              'pytype/pytd/builtins',
               'pytype/pytd/parse',
              ],
     scripts=['scripts/pytype', 'scripts/pytd'],


### PR DESCRIPTION
pytest need to access `pytype/pytd/builtins/__builtin__.py` at runtime, but it isn't installed explicitly, this PR fixes that.
