### PR TITLE
Use an official Github URL in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "typeshed"]
 	path = typeshed
-	url = http://github.com/python/typeshed
+	url = https://github.com/python/typeshed.git


### PR DESCRIPTION
The former version had a problem with our proxy.