### PR TITLE
typeshed/stdlib/2.7 has been moved to .../2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def scan_package_data(path, pattern):
 
 
 typeshed = scan_package_data('typeshed', '*.pyi')
-assert 'typeshed/stdlib/2.7/*.pyi' in typeshed
+assert 'typeshed/stdlib/2/*.pyi' in typeshed
 
 parser_ext = Extension(
     'pytype.pyi.parser_ext',


### PR DESCRIPTION
This fixes the install problem that prevents pytype to install in the typeshed tests, as reported here:
https://travis-ci.org/python/typeshed/jobs/200196205