### PR TITLE
Support loading of 3rd party stubs from typeshed.

### DIFF
--- a/pytype/load_pytd.py
+++ b/pytype/load_pytd.py
@@ -243,6 +243,7 @@ class Loader(object):
     log.debug("Trying to import %r", module_name)
     # Builtin modules (but not standard library modules!) take precedence
     # over modules in PYTHONPATH.
+    # XXX typeshed no longer has a builtins subdir.
     mod = self._load_builtin("builtins", module_name)
     if mod:
       return mod
@@ -250,6 +251,11 @@ class Loader(object):
     file_ast = self._import_file(module_name, module_name.split("."))
     if file_ast:
       return file_ast
+
+    # Try a third party module (typically site-packages).
+    mod = self._load_builtin("third_party", module_name)
+    if mod:
+      return mod
 
     # The standard library is (typically) at the end of PYTHONPATH.
     mod = self._load_builtin("stdlib", module_name)

--- a/pytype/load_pytd.py
+++ b/pytype/load_pytd.py
@@ -243,7 +243,8 @@ class Loader(object):
     log.debug("Trying to import %r", module_name)
     # Builtin modules (but not standard library modules!) take precedence
     # over modules in PYTHONPATH.
-    # XXX typeshed no longer has a builtins subdir.
+    # Note: while typeshed no longer has a builtins subdir, the pytd
+    # tree still does, and order is important here.
     mod = self._load_builtin("builtins", module_name)
     if mod:
       return mod
@@ -252,13 +253,13 @@ class Loader(object):
     if file_ast:
       return file_ast
 
-    # Try a third party module (typically site-packages).
-    mod = self._load_builtin("third_party", module_name)
+    # The standard library is (typically) towards the end of PYTHONPATH.
+    mod = self._load_builtin("stdlib", module_name)
     if mod:
       return mod
 
-    # The standard library is (typically) at the end of PYTHONPATH.
-    mod = self._load_builtin("stdlib", module_name)
+    # Third party modules (typically site-packages) come last.
+    mod = self._load_builtin("third_party", module_name)
     if mod:
       return mod
 

--- a/pytype/pytd/typeshed.py
+++ b/pytype/pytd/typeshed.py
@@ -37,8 +37,9 @@ class Typeshed(object):
         return filename, f.read()
     else:
       # Use typeshed bundled with pytype
-      data = utils.load_pytype_file(os.path.join("typeshed", path))
-      return os.path.join(self._typeshed_path, path), data
+      filename = os.path.join(self._typeshed_path, path)
+      data = utils.load_pytype_file(filename)
+      return filename, data
 
   def _load_missing(self):
     return set()


### PR DESCRIPTION
Also fix an inconsistency in how files are actually loaded.

This is most likely wrong; I'd be happy to see how this should be done. There are really two separate fixes here:

- The fix to load_pytd.py tries to load a module from the typeshed/third_party tree before trying stdlib. (It also adds an XXX comment pointing out that the logic for finding builtin modules doesn't work any more for typeshed. But perhaps that doesn't matter, because there are only a few modules that require this behavior, and presumably you have pytd files for those still.)
- The other fix makes the way `Typeshed._load_file()` loads a file consistent: the original code was hardcoding the pathname but then returning the pathname computed from `self._typeshed_path`. But maybe that was intentional? This didn't actually break me AFAIK, but I ran into the inconsistency when tracing through the code.

Question: How are tests run? There's nothing in your README.md about that.