### PR TITLE
Add a convenience script to build all pytype targets.

### DIFF
--- a/build_scripts/build.py
+++ b/build_scripts/build.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""A convenience script to build all pytype targets.
+
+Usage:
+  $> build.py [-c]
+
+Specifying the -c option forces a clobber before building.
+"""
+
+import argparse
+
+import build_utils
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--clobber", "-c", action="store_true", default=False,
+                      help="Force clobber before building.")
+  return parser.parse_args()
+
+
+def main():
+  options = parse_args()
+  if not build_utils.run_cmake(force_clean=options.clobber):
+    return 1
+  if not build_utils.run_ninja(["all"], fail_fast=True):
+    return 1
+
+
+if __name__ == "__main__":
+  main()

--- a/build_scripts/run_tests.py
+++ b/build_scripts/run_tests.py
@@ -19,9 +19,6 @@ import sys
 import build_utils
 import test_module
 
-NINJA_FAILURE_PREFIX = "FAILED: "
-
-
 def parse_args():
   """Parse the args to this script and return the list of modules passed."""
   parser = argparse.ArgumentParser()
@@ -61,66 +58,6 @@ class FailCollector(object):
       print("** %s - %s" % (mod_name, log_file))
 
 
-def run_ninja(targets, fail_collector, fail_fast=False):
-  """Run ninja over the list of specified targets.
-
-  Arguments:
-    targets: The list of test targets to run.
-    fail_collector: A FailCollector object to collect failures.
-    fail_fast: If True, abort at the first target failure.
-
-  Returns:
-    True if no target fails. False, otherwise.
-  """
-  # The -k option to ninja, set to a very high value, makes it run until it
-  # detects all failures. So, we set it to a high value unless |fail_fast| is
-  # True.
-  cmd = ["ninja", "-k", "1" if fail_fast else "100000"] + targets
-  process = subprocess.Popen(cmd, cwd=build_utils.OUT_DIR,
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-  failed_targets = []
-  with open(build_utils.NINJA_LOG, "w") as ninja_log:
-    while True:
-      line = process.stdout.readline()
-      if not line:
-        break
-      if sys.version_info.major >= 3:
-        # process.stdout.readline() always returns a 'bytes' object.
-        line = line.decode("utf-8")
-      ninja_log.write(line)
-      if line.startswith(NINJA_FAILURE_PREFIX):
-        # This is a failed ninja target.
-        failed_targets.append(line[len(NINJA_FAILURE_PREFIX):].strip())
-      modname, logfile = test_module.get_module_and_log_file_from_result_msg(line)
-      if modname:
-        print(line)
-      if logfile:
-        assert modname
-        if fail_collector:
-          fail_collector.add_failure(modname, logfile)
-    if failed_targets:
-      # For convenience, we will print the list of failed targets.
-      summary_hdr = ">>> Detected Ninja target failures:"
-      print("\n" + summary_hdr)
-      ninja_log.write("\n" + summary_hdr + "\n")
-      for t in failed_targets:
-        target = "    - %s" % t
-        print(target)
-        ninja_log.write(target + "\n")
-  process.wait()
-  if process.returncode == 0:
-    return True
-  else:
-    # Ninja output can be a lot. Printing it here will clutter the output of
-    # this script. So, just tell the user how to repro the error.
-    print(">>> FAILED: Ninja command '%s'." % " ".join(cmd))
-    print(">>>         Run it in the 'out' directory to reproduce.")
-    print(">>>         Full Ninja output is available in '%s'." %
-          build_utils.NINJA_LOG)
-    print(">>>         Failing test modules (if any) will be reported below.")
-    return False
-
-
 def main():
   opts = parse_args()
   modules = opts.modules or ["test_all"]
@@ -130,7 +67,7 @@ def main():
   # PyType's target names use the dotted name convention. So, the fully
   # qualified test module names are actually ninja target names.
   print("Running tests (build steps will be executed as required) ...\n")
-  if not run_ninja(modules, fail_collector, fail_fast=opts.fail_fast):
+  if not build_utils.run_ninja(modules, fail_collector, opts.fail_fast):
     fail_collector.print_report()
     sys.exit(1)
   print("!!! All tests passed !!!\n"

--- a/build_scripts/test_module.py
+++ b/build_scripts/test_module.py
@@ -32,31 +32,7 @@ import sys
 import traceback
 import unittest
 
-PYTYPE_SRC_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-_FAILURE_MSG_PREFIX = ">>> FAIL"
-_PASS_MSG_PREFIX = ">>> PASS"
-_RESULT_MSG_SEP = " - "
-
-
-def get_module_and_log_file_from_result_msg(msg):
-  if msg.startswith(_FAILURE_MSG_PREFIX):
-    _, mod_name, log_file = msg.split(_RESULT_MSG_SEP)
-    return mod_name, log_file
-  if msg.startswith(_PASS_MSG_PREFIX):
-    _, mod_name = msg.split(_RESULT_MSG_SEP)
-    return mod_name, None
-  return None, None
-
-
-def failure_msg(mod_name, log_file):
-  components = [_FAILURE_MSG_PREFIX, mod_name]
-  if log_file:
-    components.append(log_file)
-  return _RESULT_MSG_SEP.join(components)
-
-
-def pass_msg(mod_name):
-  return _RESULT_MSG_SEP.join([_PASS_MSG_PREFIX, mod_name])
+import build_utils
 
 
 def print_messages(options, stdout_msg, output_file_msg):
@@ -147,7 +123,7 @@ def parse_args():
   parser.add_argument("fq_mod_name", type=str, metavar="FQ_MOD_NAME",
                       help="Fully qualified name of the test module to run.")
   parser.add_argument("-P", "--pytype_path", type=str,
-                      default=PYTYPE_SRC_ROOT,
+                      default=build_utils.PYTYPE_SRC_ROOT,
                       help="Path in which the pytype package can be found.")
   parser.add_argument("-o", "--output", type=str,
                       help="Path to the results file.")
@@ -243,10 +219,10 @@ def main():
   else:
     result = run(None)
   if result != 0:
-    print(failure_msg(options.fq_mod_name, options.output))
+    print(build_utils.failure_msg(options.fq_mod_name, options.output))
     sys.exit(1)
   else:
-    print(pass_msg(options.fq_mod_name))
+    print(build_utils.pass_msg(options.fq_mod_name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This script will be expanded in a later pass to add options to build
the executables like 'pytype' and 'pytype-single' with C++ logging
enabled.