### PR TITLE
Add --debug option to the scripts build.py and run_tests.py

### DIFF
--- a/build_scripts/build.py
+++ b/build_scripts/build.py
@@ -7,6 +7,8 @@ Usage:
 Specifying the -c option forces a clobber before building.
 """
 
+from __future__ import print_function
+
 import argparse
 
 import build_utils
@@ -15,15 +17,20 @@ def parse_args():
   parser = argparse.ArgumentParser()
   parser.add_argument("--clobber", "-c", action="store_true", default=False,
                       help="Force clobber before building.")
+  parser.add_argument("--debug", "-d", action="store_true", default=False,
+                      help="Build targets in the debug mode.")
   return parser.parse_args()
 
 
 def main():
   options = parse_args()
-  if not build_utils.run_cmake(force_clean=options.clobber):
+  if not build_utils.run_cmake(force_clean=options.clobber, log_output=True,
+                               debug_build=options.debug):
     return 1
+  print("Building all targets with Ninja ...\n")
   if not build_utils.run_ninja(["all"], fail_fast=True):
     return 1
+  print("Build successful!\n")
 
 
 if __name__ == "__main__":

--- a/build_scripts/build_utils.py
+++ b/build_scripts/build_utils.py
@@ -39,7 +39,7 @@ def current_py_version():
 
 
 class BuildConfig(object):
-  """Utility class to manage the Python version cache."""
+  """Utility class to create and manage the build config cache."""
 
   BUILD_CONFIG_CACHE = os.path.join(OUT_DIR, ".build_config.json")
 

--- a/build_scripts/run_tests.py
+++ b/build_scripts/run_tests.py
@@ -26,6 +26,8 @@ def parse_args():
                       help="List of test modules to run.")
   parser.add_argument("--fail_fast", "-f", action="store_true", default=False,
                       help="Fail as soon as one build target fails.")
+  parser.add_argument("--debug", "-d", action="store_true", default=False,
+                      help="Build targets in the debug mode.")
   args = parser.parse_args()
   for module in args.modules:
     if "." in module:
@@ -43,7 +45,7 @@ def parse_args():
 def main():
   opts = parse_args()
   modules = opts.modules or ["test_all"]
-  if not build_utils.run_cmake(log_output=True):
+  if not build_utils.run_cmake(log_output=True, debug_build=opts.debug):
     sys.exit(1)
   fail_collector = build_utils.FailCollector()
   # PyType's target names use the dotted name convention. So, the fully


### PR DESCRIPTION
Specifying this option builds all Pytype targets in the debug mode. It is useful, for example, to enable C++ logging.

