### PR TITLE
Fix repeated "the" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,5 +74,5 @@ tests for which `py_test` targets exist in the CMake files.
 
 ### The small print
 Contributions made by corporations are covered by a different agreement than
-the one mentioned above; they're covered by the the Software Grant and
+the one mentioned above; they're covered by the Software Grant and
 Corporate Contributor License Agreement.


### PR DESCRIPTION
Import of GitHub PR #67: Fix repeated "the" in CONTRIBUTING.md
https://github.com/google/pytype/pull/67
Resolves #67

Last section ("The small print") has a repeated "the":

> they're covered by the the Software Grant

This commit fixes that.
Merge 57aead5d81540479dd598fd261029e216fe343d8 into 5fbe24a055fa22e973d946479e3e71ec0c4be086

PiperOrigin-RevId: 207619395