### PR TITLE
Update the type annotations backporting patch.

### DIFF
--- a/2.7_patches/python_2_7_type_annotations.diff
+++ b/2.7_patches/python_2_7_type_annotations.diff
@@ -6,19 +6,19 @@ Example:
     def f(x: int, y: int) -> Tuple[int, ...]
 
 diff --git a/Doc/library/dis.rst b/Doc/library/dis.rst
-index 8dee901..58e115c 100644
+index 04b9b15386..c99031b7cf 100644
 --- a/Doc/library/dis.rst
 +++ b/Doc/library/dis.rst
-@@ -804,19 +804,20 @@ the more significant byte last.
-    the function itself off the stack, and pushes the return value.
+@@ -813,19 +813,23 @@ the more significant byte last.
+    value.
  
  
 -.. opcode:: MAKE_FUNCTION (argc)
 +.. opcode:: MAKE_FUNCTION (argc | types << 16)
  
-    Pushes a new function object on the stack.  TOS is the code associated with the
--   function.  The function object is defined to have *argc* default parameters,
--   which are found below TOS.
+    Pushes a new function object on the stack.  TOS is the code associated with
+    the function.  The function object is defined to have *argc* default
+    parameters, which are found below TOS.
 +   function.  The function object is defined to have *argc* default parameters, and
 +   *types* argument types, which are found below TOS, in that order.
  
@@ -29,14 +29,14 @@ index 8dee901..58e115c 100644
     Creates a new function object, sets its *func_closure* slot, and pushes it on
     the stack.  TOS is the code associated with the function, TOS1 the tuple
     containing cells for the closure's free variables.  The function also has
--   *argc* default parameters, which are found below the cells.
+    *argc* default parameters, which are found below the cells.
 +   *argc* default parameters and *types* argument types, which are found below
 +   the cells (default parameters first, then types).
  
  
  .. opcode:: BUILD_SLICE (argc)
 diff --git a/Grammar/Grammar b/Grammar/Grammar
-index 4c3f33d..e495d8f 100644
+index 4c3f33da32..e495d8fc1d 100644
 --- a/Grammar/Grammar
 +++ b/Grammar/Grammar
 @@ -22,13 +22,18 @@ eval_input: testlist NEWLINE* ENDMARKER
@@ -87,7 +87,7 @@ index 4c3f33d..e495d8f 100644
  exprlist: expr (',' expr)* [',']
  testlist: test (',' test)* [',']
 diff --git a/Include/Python-ast.h b/Include/Python-ast.h
-index 3f35bbb..dbabc9a 100644
+index 3f35bbb634..dbabc9ab57 100644
 --- a/Include/Python-ast.h
 +++ b/Include/Python-ast.h
 @@ -73,6 +73,7 @@ struct _stmt {
@@ -170,7 +170,7 @@ index 3f35bbb..dbabc9a 100644
  keyword_ty _Py_keyword(identifier arg, expr_ty value, PyArena *arena);
  #define alias(a0, a1, a2) _Py_alias(a0, a1, a2)
 diff --git a/Include/code.h b/Include/code.h
-index 38b2958..0c27529 100644
+index 7456fd610f..138e694527 100644
 --- a/Include/code.h
 +++ b/Include/code.h
 @@ -52,6 +52,7 @@ typedef struct {
@@ -182,7 +182,7 @@ index 38b2958..0c27529 100644
  /* This should be defined if a future statement modifies the syntax.
     For example, when a keyword is added.
 diff --git a/Include/compile.h b/Include/compile.h
-index 6100101..09452f0 100644
+index 61001016aa..09452f09ca 100644
 --- a/Include/compile.h
 +++ b/Include/compile.h
 @@ -26,6 +26,7 @@ typedef struct {
@@ -194,7 +194,7 @@ index 6100101..09452f0 100644
  
  struct _mod; /* Declare the existence of this type */
 diff --git a/Include/graminit.h b/Include/graminit.h
-index 40d531e..df92c6d 100644
+index 40d531e8a1..df92c6dbb5 100644
 --- a/Include/graminit.h
 +++ b/Include/graminit.h
 @@ -8,80 +8,83 @@
@@ -359,10 +359,10 @@ index 40d531e..df92c6d 100644
 +#define encoding_decl 342
 +#define yield_expr 343
 diff --git a/Include/opcode.h b/Include/opcode.h
-index 9764109..9518006 100644
+index 9ed548729e..03f7b5a740 100644
 --- a/Include/opcode.h
 +++ b/Include/opcode.h
-@@ -128,10 +128,10 @@ extern "C" {
+@@ -137,10 +137,10 @@ extern "C" {
  #define RAISE_VARARGS	130	/* Number of raise arguments (1, 2 or 3) */
  /* CALL_FUNCTION_XXX opcodes defined below depend on this definition */
  #define CALL_FUNCTION	131	/* #args + (#kwargs<<8) */
@@ -376,7 +376,7 @@ index 9764109..9518006 100644
  #define LOAD_DEREF      136     /* Load and dereference from closure cell */ 
  #define STORE_DEREF     137     /* Store into cell */ 
 diff --git a/Include/parsetok.h b/Include/parsetok.h
-index ec1eb6f..e0f2c79 100644
+index ec1eb6ff7d..e0f2c7943b 100644
 --- a/Include/parsetok.h
 +++ b/Include/parsetok.h
 @@ -29,6 +29,7 @@ typedef struct {
@@ -388,7 +388,7 @@ index ec1eb6f..e0f2c79 100644
  
  
 diff --git a/Include/pydebug.h b/Include/pydebug.h
-index 0f45960..db15d3c 100644
+index 0f45960f90..db15d3cd92 100644
 --- a/Include/pydebug.h
 +++ b/Include/pydebug.h
 @@ -10,6 +10,7 @@ PyAPI_DATA(int) Py_VerboseFlag;
@@ -400,7 +400,7 @@ index 0f45960..db15d3c 100644
  PyAPI_DATA(int) Py_BytesWarningFlag;
  PyAPI_DATA(int) Py_UseClassExceptionsFlag;
 diff --git a/Include/pythonrun.h b/Include/pythonrun.h
-index 6bfc175..0f7c7a7 100644
+index f0f4e382e5..6d8ade8805 100644
 --- a/Include/pythonrun.h
 +++ b/Include/pythonrun.h
 @@ -9,7 +9,8 @@ extern "C" {
@@ -414,7 +414,7 @@ index 6bfc175..0f7c7a7 100644
  #define PyCF_SOURCE_IS_UTF8  0x0100
  #define PyCF_DONT_IMPLY_DEDENT 0x0200
 diff --git a/Include/token.h b/Include/token.h
-index 72659ac..afb3fe1 100644
+index 72659ac053..afb3fe1c01 100644
 --- a/Include/token.h
 +++ b/Include/token.h
 @@ -60,10 +60,12 @@ extern "C" {
@@ -434,7 +434,7 @@ index 72659ac..afb3fe1 100644
  /* Special definitions for cooperation with parser */
  
 diff --git a/Lib/__future__.py b/Lib/__future__.py
-index e0996eb..95fd96f 100644
+index e0996eb007..95fd96fef2 100644
 --- a/Lib/__future__.py
 +++ b/Lib/__future__.py
 @@ -55,6 +55,7 @@ all_feature_names = [
@@ -462,7 +462,7 @@ index e0996eb..95fd96f 100644
 +                                   (3, 0, 0, "alpha", 0),
 +                                   CO_FUTURE_GOOGLE_TYPE_ANNOTATIONS)
 diff --git a/Lib/compiler/future.py b/Lib/compiler/future.py
-index fd5e5df..259026f 100644
+index fd5e5dfb37..259026fcd3 100644
 --- a/Lib/compiler/future.py
 +++ b/Lib/compiler/future.py
 @@ -17,7 +17,7 @@ class FutureParser:
@@ -475,7 +475,7 @@ index fd5e5df..259026f 100644
      def __init__(self):
          self.found = {} # set
 diff --git a/Lib/compiler/pyassem.py b/Lib/compiler/pyassem.py
-index f52f7d0..8bb1b21 100644
+index b82073e4d1..f2ddfb6111 100644
 --- a/Lib/compiler/pyassem.py
 +++ b/Lib/compiler/pyassem.py
 @@ -748,10 +748,10 @@ class StackDepthTracker:
@@ -492,7 +492,7 @@ index f52f7d0..8bb1b21 100644
          if argc == 2:
              return -1
 diff --git a/Lib/compiler/pycodegen.py b/Lib/compiler/pycodegen.py
-index 6515945..f4387db 100644
+index 6515945f39..f4387db016 100644
 --- a/Lib/compiler/pycodegen.py
 +++ b/Lib/compiler/pycodegen.py
 @@ -387,7 +387,7 @@ class CodeGenerator:
@@ -544,7 +544,7 @@ index 6515945..f4387db 100644
          self.visit(node.code.quals[0].iter)
          self.emit('GET_ITER')
 diff --git a/Lib/compiler/transformer.py b/Lib/compiler/transformer.py
-index d4f4613..04d01f7 100644
+index ba5c03ce75..618560ba8c 100644
 --- a/Lib/compiler/transformer.py
 +++ b/Lib/compiler/transformer.py
 @@ -245,23 +245,26 @@ class Transformer:
@@ -636,7 +636,7 @@ index d4f4613..04d01f7 100644
              return self.com_fplist(node[2])
          return node[1][1]
 diff --git a/Lib/symbol.py b/Lib/symbol.py
-index b4d4e13..cf83edb 100755
+index b4d4e13ab8..cf83edb132 100755
 --- a/Lib/symbol.py
 +++ b/Lib/symbol.py
 @@ -18,83 +18,86 @@ decorators = 260
@@ -804,7 +804,7 @@ index b4d4e13..cf83edb 100755
  
  sym_name = {}
 diff --git a/Lib/test/test_ast.py b/Lib/test/test_ast.py
-index 0a1ca41..c6ad031 100644
+index 0a1ca4168a..c6ad031396 100644
 --- a/Lib/test/test_ast.py
 +++ b/Lib/test/test_ast.py
 @@ -227,6 +227,25 @@ class AST_Tests(unittest.TestCase):
@@ -885,15 +885,15 @@ index 0a1ca41..c6ad031 100644
  ('Expression', ('Dict', (1, 0), [], [])),
  ('Expression', ('Set', (1, 0), [('Name', (1, 1), 'None', ('Load',))])),
 diff --git a/Lib/test/test_compile.py b/Lib/test/test_compile.py
-index 4bcb438..c1f9372 100644
+index e954a0ce74..1d8556e1d1 100644
 --- a/Lib/test/test_compile.py
 +++ b/Lib/test/test_compile.py
 @@ -1,3 +1,4 @@
 +from __future__ import google_type_annotations
+ import math
  import unittest
  import sys
- import _ast
-@@ -193,6 +194,52 @@ def f(x):
+@@ -218,6 +219,52 @@ def f(x):
          self.assertEqual(comp_args(), (2, 3, 4))
          ''')
  
@@ -946,7 +946,7 @@ index 4bcb438..c1f9372 100644
      def test_argument_order(self):
          try:
              exec 'def f(a=1, (b, c)): pass'
-@@ -465,6 +512,14 @@ if 1:
+@@ -505,6 +552,14 @@ if 1:
          self.assertEqual(d[..., ...], 2)
          del d[..., ...]
          self.assertNotIn((Ellipsis, Ellipsis), d)
@@ -962,7 +962,7 @@ index 4bcb438..c1f9372 100644
      def test_mangling(self):
          class A:
 diff --git a/Lib/test/test_compiler.py b/Lib/test/test_compiler.py
-index 4598811..cd00a23 100644
+index c98e494742..be1cb96b62 100644
 --- a/Lib/test/test_compiler.py
 +++ b/Lib/test/test_compiler.py
 @@ -87,6 +87,28 @@ class CompilerTest(unittest.TestCase):
@@ -995,10 +995,10 @@ index 4598811..cd00a23 100644
          c = compiler.compile('"doc"', '<string>', 'exec')
          self.assertIn('__doc__', c.co_names)
 diff --git a/Lib/test/test_parser.py b/Lib/test/test_parser.py
-index 65a762c..f43f97e 100644
+index 73974a96f0..dbc93c5e8b 100644
 --- a/Lib/test/test_parser.py
 +++ b/Lib/test/test_parser.py
-@@ -123,6 +123,14 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
+@@ -125,6 +125,14 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
          self.check_expr("(x for x in range(10))")
          self.check_expr("foo(x for x in range(10))")
  
@@ -1013,7 +1013,7 @@ index 65a762c..f43f97e 100644
      def test_print(self):
          self.check_suite("print")
          self.check_suite("print 1")
-@@ -172,6 +180,25 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
+@@ -174,6 +182,25 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
          self.check_suite("def f(a, b, foo=bar, *args, **kw): pass")
          self.check_suite("def f(a, b, foo=bar, **kw): pass")
  
@@ -1040,10 +1040,10 @@ index 65a762c..f43f97e 100644
                           "def f(): pass")
          self.check_suite("@staticmethod\n"
 diff --git a/Lib/token.py b/Lib/token.py
-index 34abf62..189697c 100755
+index 45825b4a77..c9dac79437 100644
 --- a/Lib/token.py
 +++ b/Lib/token.py
-@@ -61,9 +61,11 @@ DOUBLESTAREQUAL = 47
+@@ -59,9 +59,11 @@ DOUBLESTAREQUAL = 47
  DOUBLESLASH = 48
  DOUBLESLASHEQUAL = 49
  AT = 50
@@ -1059,10 +1059,10 @@ index 34abf62..189697c 100755
  #--end constants--
  
 diff --git a/Lib/tokenize.py b/Lib/tokenize.py
-index ca7b074..88a1122 100644
+index 6c857f8547..b4132da853 100644
 --- a/Lib/tokenize.py
 +++ b/Lib/tokenize.py
-@@ -79,7 +79,7 @@ String = group(r"[uUbB]?[rR]?'[^\n'\\]*(?:\\.[^\n'\\]*)*'",
+@@ -80,7 +80,7 @@ String = group(r"[uUbB]?[rR]?'[^\n'\\]*(?:\\.[^\n'\\]*)*'",
  # longest operators first (e.g., if = came before ==, == would get
  # recognized as two instances of =).
  Operator = group(r"\*\*=?", r">>=?", r"<<=?", r"<>", r"!=",
@@ -1072,10 +1072,10 @@ index ca7b074..88a1122 100644
                   r"~")
  
 diff --git a/Modules/main.c b/Modules/main.c
-index ef9b245..8507feb 100644
+index a6edf822d0..6d43051344 100644
 --- a/Modules/main.c
 +++ b/Modules/main.c
-@@ -40,7 +40,7 @@ static char **orig_argv;
+@@ -43,7 +43,7 @@ static char **orig_argv;
  static int  orig_argc;
  
  /* command line options */
@@ -1084,7 +1084,7 @@ index ef9b245..8507feb 100644
  
  #ifndef RISCOS
  #define PROGRAM_OPTS BASE_OPTS
-@@ -71,6 +71,7 @@ static char *usage_2 = "\
+@@ -76,6 +76,7 @@ static char *usage_2 = "\
  -m mod : run library module as a script (terminates option list)\n\
  -O     : optimize generated bytecode slightly; also PYTHONOPTIMIZE=x\n\
  -OO    : remove doc-strings in addition to the -O optimizations\n\
@@ -1092,7 +1092,7 @@ index ef9b245..8507feb 100644
  -R     : use a pseudo-random salt to make hash() values of various types be\n\
           unpredictable between separate invocations of the interpreter, as\n\
           a defense against denial-of-service attacks\n\
-@@ -370,6 +371,10 @@ Py_Main(int argc, char **argv)
+@@ -375,6 +376,10 @@ Py_Main(int argc, char **argv)
              Py_OptimizeFlag++;
              break;
  
@@ -1104,10 +1104,10 @@ index ef9b245..8507feb 100644
              Py_DontWriteBytecodeFlag++;
              break;
 diff --git a/Modules/parsermodule.c b/Modules/parsermodule.c
-index eb2d600..0ae2a38 100644
+index fcc618d5d9..f06bc91990 100644
 --- a/Modules/parsermodule.c
 +++ b/Modules/parsermodule.c
-@@ -972,6 +972,7 @@ VALIDATER(comp_iter);           VALIDATER(comp_if);
+@@ -1014,6 +1014,7 @@ VALIDATER(comp_iter);           VALIDATER(comp_if);
  VALIDATER(testlist_comp);       VALIDATER(yield_expr);
  VALIDATER(yield_or_testlist);   VALIDATER(or_test);
  VALIDATER(old_test);            VALIDATER(old_lambdef);
@@ -1115,7 +1115,7 @@ index eb2d600..0ae2a38 100644
  
  #undef VALIDATER
  
-@@ -1129,7 +1130,7 @@ validate_if(node *tree)
+@@ -1171,7 +1172,7 @@ validate_if(node *tree)
  
  
  /*  parameters:
@@ -1124,7 +1124,7 @@ index eb2d600..0ae2a38 100644
   *
   */
  static int
-@@ -1142,7 +1143,7 @@ validate_parameters(node *tree)
+@@ -1184,7 +1185,7 @@ validate_parameters(node *tree)
          res = (validate_lparen(CHILD(tree, 0))
                 && validate_rparen(CHILD(tree, nch - 1)));
          if (res && (nch == 3))
@@ -1133,7 +1133,7 @@ index eb2d600..0ae2a38 100644
      }
      else {
          (void) validate_numnodes(tree, 2, "parameters");
-@@ -1208,6 +1209,25 @@ validate_testlist_safe(node *tree)
+@@ -1250,6 +1251,25 @@ validate_testlist_safe(node *tree)
                                      validate_old_test, "testlist_safe"));
  }
  
@@ -1159,7 +1159,7 @@ index eb2d600..0ae2a38 100644
  
  /* '*' NAME [',' '**' NAME] | '**' NAME
   */
-@@ -1226,42 +1246,36 @@ validate_varargslist_trailer(node *tree, int start)
+@@ -1268,42 +1288,36 @@ validate_varargslist_trailer(node *tree, int start)
      if (sym == STAR) {
          /*
           *  ('*' NAME [',' '**' NAME]
@@ -1213,7 +1213,7 @@ index eb2d600..0ae2a38 100644
      int sym;
  
      if (!res)
-@@ -1351,11 +1365,61 @@ validate_varargslist(node *tree)
+@@ -1393,11 +1407,61 @@ validate_varargslist(node *tree)
                  err_string("illegal formation for varargslist");
              }
          }
@@ -1275,7 +1275,7 @@ index eb2d600..0ae2a38 100644
  /*  list_iter:  list_for | list_if
   */
  static int
-@@ -2520,6 +2584,7 @@ validate_atom(node *tree)
+@@ -2562,6 +2626,7 @@ validate_atom(node *tree)
              break;
            case NAME:
            case NUMBER:
@@ -1283,7 +1283,7 @@ index eb2d600..0ae2a38 100644
              res = (nch == 1);
              break;
            case STRING:
-@@ -2688,19 +2753,19 @@ validate_with_stmt(node *tree)
+@@ -2730,19 +2795,19 @@ validate_with_stmt(node *tree)
  
  /*  funcdef:
   *
@@ -1310,7 +1310,7 @@ index eb2d600..0ae2a38 100644
      return ok;
  }
 diff --git a/Parser/Python.asdl b/Parser/Python.asdl
-index 9a9b933..aa252c1 100644
+index 9a9b933143..aa252c1d51 100644
 --- a/Parser/Python.asdl
 +++ b/Parser/Python.asdl
 @@ -10,7 +10,7 @@ module Python version "$Revision$"
@@ -1352,7 +1352,7 @@ index 9a9b933..aa252c1 100644
          -- keyword arguments supplied to call
          keyword = (identifier arg, expr value)
 diff --git a/Parser/parser.c b/Parser/parser.c
-index b753a17..b2337c1 100644
+index b753a177c8..b2337c160f 100644
 --- a/Parser/parser.c
 +++ b/Parser/parser.c
 @@ -210,6 +210,8 @@ future_hack(parser_state *ps)
@@ -1365,7 +1365,7 @@ index b753a17..b2337c1 100644
          }
      }
 diff --git a/Parser/parsetok.c b/Parser/parsetok.c
-index 069cc6b..612f434 100644
+index 069cc6b711..612f434708 100644
 --- a/Parser/parsetok.c
 +++ b/Parser/parsetok.c
 @@ -146,6 +146,9 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
@@ -1379,7 +1379,7 @@ index 069cc6b..612f434 100644
  #endif
  
 diff --git a/Parser/tokenizer.c b/Parser/tokenizer.c
-index 46cf9b2..59d14f3 100644
+index 61bfb4e1b7..aaaf4337e0 100644
 --- a/Parser/tokenizer.c
 +++ b/Parser/tokenizer.c
 @@ -86,6 +86,8 @@ char *_PyParser_TokenNames[] = {
@@ -1391,7 +1391,7 @@ index 46cf9b2..59d14f3 100644
      /* This table must match the #defines in token.h! */
      "OP",
      "<ERRORTOKEN>",
-@@ -1082,6 +1084,7 @@ PyToken_TwoChars(int c1, int c2)
+@@ -1108,6 +1110,7 @@ PyToken_TwoChars(int c1, int c2)
      case '-':
          switch (c2) {
          case '=':               return MINEQUAL;
@@ -1399,7 +1399,7 @@ index 46cf9b2..59d14f3 100644
          }
          break;
      case '*':
-@@ -1164,6 +1167,16 @@ PyToken_ThreeChars(int c1, int c2, int c3)
+@@ -1190,6 +1193,16 @@ PyToken_ThreeChars(int c1, int c2, int c3)
              break;
          }
          break;
@@ -1416,7 +1416,7 @@ index 46cf9b2..59d14f3 100644
      }
      return OP;
  }
-@@ -1390,13 +1403,22 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
+@@ -1416,13 +1429,22 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
          c = tok_nextc(tok);
          if (isdigit(c)) {
              goto fraction;
@@ -1445,7 +1445,7 @@ index 46cf9b2..59d14f3 100644
  
      /* Number */
 diff --git a/Python/Python-ast.c b/Python/Python-ast.c
-index 6cf99ec..c62c4ff 100644
+index 2e7a1afbbc..7ec46b489a 100644
 --- a/Python/Python-ast.c
 +++ b/Python/Python-ast.c
 @@ -42,6 +42,7 @@ static char *FunctionDef_fields[]={
@@ -1651,7 +1651,7 @@ index 6cf99ec..c62c4ff 100644
          return result;
  failed:
          Py_XDECREF(value);
-@@ -3512,6 +3544,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
+@@ -3524,6 +3556,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                  identifier name;
                  arguments_ty args;
                  asdl_seq* body;
@@ -1659,7 +1659,7 @@ index 6cf99ec..c62c4ff 100644
                  asdl_seq* decorator_list;
  
                  if (PyObject_HasAttrString(obj, "name")) {
-@@ -3563,6 +3596,17 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
+@@ -3579,6 +3612,17 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                          PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from FunctionDef");
                          return 1;
                  }
@@ -1677,7 +1677,7 @@ index 6cf99ec..c62c4ff 100644
                  if (PyObject_HasAttrString(obj, "decorator_list")) {
                          int res;
                          Py_ssize_t len;
-@@ -3588,8 +3632,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
+@@ -3608,8 +3652,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                          PyErr_SetString(PyExc_TypeError, "required field \"decorator_list\" missing from FunctionDef");
                          return 1;
                  }
@@ -1688,7 +1688,7 @@ index 6cf99ec..c62c4ff 100644
                  if (*out == NULL) goto failed;
                  return 0;
          }
-@@ -5750,6 +5794,16 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
+@@ -5910,6 +5954,16 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                  if (*out == NULL) goto failed;
                  return 0;
          }
@@ -1705,7 +1705,7 @@ index 6cf99ec..c62c4ff 100644
  
          tmp = PyObject_Repr(obj);
          if (tmp == NULL) goto failed;
-@@ -5833,16 +5887,6 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
+@@ -5993,16 +6047,6 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
                  *out = NULL;
                  return 0;
          }
@@ -1722,7 +1722,7 @@ index 6cf99ec..c62c4ff 100644
          isinstance = PyObject_IsInstance(obj, (PyObject*)Slice_type);
          if (isinstance == -1) {
                  return 1;
-@@ -6418,8 +6462,11 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
+@@ -6590,8 +6634,11 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
          PyObject* tmp = NULL;
          asdl_seq* args;
          identifier vararg;
@@ -1734,7 +1734,7 @@ index 6cf99ec..c62c4ff 100644
  
          if (PyObject_HasAttrString(obj, "args")) {
                  int res;
-@@ -6457,6 +6504,17 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
+@@ -6633,6 +6680,17 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
          } else {
                  vararg = NULL;
          }
@@ -1752,7 +1752,7 @@ index 6cf99ec..c62c4ff 100644
          if (PyObject_HasAttrString(obj, "kwarg")) {
                  int res;
                  tmp = PyObject_GetAttrString(obj, "kwarg");
-@@ -6468,6 +6526,17 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
+@@ -6644,6 +6702,17 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
          } else {
                  kwarg = NULL;
          }
@@ -1770,7 +1770,7 @@ index 6cf99ec..c62c4ff 100644
          if (PyObject_HasAttrString(obj, "defaults")) {
                  int res;
                  Py_ssize_t len;
-@@ -6493,7 +6562,33 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
+@@ -6673,7 +6742,33 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
                  PyErr_SetString(PyExc_TypeError, "required field \"defaults\" missing from arguments");
                  return 1;
          }
@@ -1805,7 +1805,7 @@ index 6cf99ec..c62c4ff 100644
          return 0;
  failed:
          Py_XDECREF(tmp);
-@@ -6667,6 +6762,8 @@ init_ast(void)
+@@ -6847,6 +6942,8 @@ init_ast(void)
          if (PyDict_SetItemString(d, "Name", (PyObject*)Name_type) < 0) return;
          if (PyDict_SetItemString(d, "List", (PyObject*)List_type) < 0) return;
          if (PyDict_SetItemString(d, "Tuple", (PyObject*)Tuple_type) < 0) return;
@@ -1814,7 +1814,7 @@ index 6cf99ec..c62c4ff 100644
          if (PyDict_SetItemString(d, "expr_context",
              (PyObject*)expr_context_type) < 0) return;
          if (PyDict_SetItemString(d, "Load", (PyObject*)Load_type) < 0) return;
-@@ -6678,8 +6775,6 @@ init_ast(void)
+@@ -6858,8 +6955,6 @@ init_ast(void)
              return;
          if (PyDict_SetItemString(d, "Param", (PyObject*)Param_type) < 0) return;
          if (PyDict_SetItemString(d, "slice", (PyObject*)slice_type) < 0) return;
@@ -1824,7 +1824,7 @@ index 6cf99ec..c62c4ff 100644
          if (PyDict_SetItemString(d, "ExtSlice", (PyObject*)ExtSlice_type) < 0)
              return;
 diff --git a/Python/ast.c b/Python/ast.c
-index fc6f002..39055b7 100644
+index 318c0bb27d..49491874c1 100644
 --- a/Python/ast.c
 +++ b/Python/ast.c
 @@ -19,6 +19,7 @@
@@ -2176,10 +2176,10 @@ index fc6f002..39055b7 100644
                  break;
              }
 diff --git a/Python/ceval.c b/Python/ceval.c
-index 06ada97..6dbbe62 100644
+index 2088a271d8..706c8a6f7f 100644
 --- a/Python/ceval.c
 +++ b/Python/ceval.c
-@@ -2721,17 +2721,28 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
+@@ -3065,17 +3065,28 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
              v = POP(); /* code object */
              x = PyFunction_New(v, f->f_globals);
              Py_DECREF(v);
@@ -2212,7 +2212,7 @@ index 06ada97..6dbbe62 100644
                  }
                  err = PyFunction_SetDefaults(x, v);
                  Py_DECREF(v);
-@@ -2752,16 +2763,18 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
+@@ -3097,16 +3108,18 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                  }
                  Py_DECREF(v);
              }
@@ -2235,7 +2235,7 @@ index 06ada97..6dbbe62 100644
                  }
                  if (PyFunction_SetDefaults(x, v) != 0) {
                      /* Can't happen unless
-@@ -2770,6 +2783,12 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
+@@ -3115,6 +3128,12 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                  }
                  Py_DECREF(v);
              }
@@ -2249,7 +2249,7 @@ index 06ada97..6dbbe62 100644
              break;
          }
 diff --git a/Python/compile.c b/Python/compile.c
-index 8354c75..a81813c 100644
+index 4fe69e12bf..bfa1466f78 100644
 --- a/Python/compile.c
 +++ b/Python/compile.c
 @@ -893,7 +893,7 @@ opcode_stack_effect(int opcode, int oparg)
@@ -2270,7 +2270,7 @@ index 8354c75..a81813c 100644
          case LOAD_CLOSURE:
              return 1;
          case LOAD_DEREF:
-@@ -1298,12 +1298,16 @@ compiler_lookup_arg(PyObject *dict, PyObject *name)
+@@ -1266,12 +1266,16 @@ compiler_lookup_arg(PyObject *dict, PyObject *name)
  }
  
  static int
@@ -2289,7 +2289,7 @@ index 8354c75..a81813c 100644
          return 1;
      }
      for (i = 0; i < free; ++i) {
-@@ -1338,7 +1342,7 @@ compiler_make_closure(struct compiler *c, PyCodeObject *co, int args)
+@@ -1306,7 +1310,7 @@ compiler_make_closure(struct compiler *c, PyCodeObject *co, int args)
      }
      ADDOP_I(c, BUILD_TUPLE, free);
      ADDOP_O(c, LOAD_CONST, (PyObject*)co, consts);
@@ -2298,7 +2298,7 @@ index 8354c75..a81813c 100644
      return 1;
  }
  
-@@ -1380,6 +1384,57 @@ compiler_arguments(struct compiler *c, arguments_ty args)
+@@ -1348,6 +1352,57 @@ compiler_arguments(struct compiler *c, arguments_ty args)
      return 1;
  }
  
@@ -2356,7 +2356,7 @@ index 8354c75..a81813c 100644
  static int
  compiler_function(struct compiler *c, stmt_ty s)
  {
-@@ -1389,13 +1444,43 @@ compiler_function(struct compiler *c, stmt_ty s)
+@@ -1357,13 +1412,43 @@ compiler_function(struct compiler *c, stmt_ty s)
      asdl_seq* decos = s->v.FunctionDef.decorator_list;
      stmt_ty st;
      int i, n, docstring;
@@ -2400,7 +2400,7 @@ index 8354c75..a81813c 100644
      if (!compiler_enter_scope(c, s->v.FunctionDef.name, (void *)s,
                                s->lineno))
          return 0;
-@@ -1424,7 +1509,7 @@ compiler_function(struct compiler *c, stmt_ty s)
+@@ -1392,7 +1477,7 @@ compiler_function(struct compiler *c, stmt_ty s)
      if (co == NULL)
          return 0;
  
@@ -2409,7 +2409,7 @@ index 8354c75..a81813c 100644
      Py_DECREF(co);
  
      for (i = 0; i < asdl_seq_LEN(decos); i++) {
-@@ -1486,7 +1571,7 @@ compiler_class(struct compiler *c, stmt_ty s)
+@@ -1453,7 +1538,7 @@ compiler_class(struct compiler *c, stmt_ty s)
      if (co == NULL)
          return 0;
  
@@ -2418,7 +2418,7 @@ index 8354c75..a81813c 100644
      Py_DECREF(co);
  
      ADDOP_I(c, CALL_FUNCTION, 0);
-@@ -1562,7 +1647,7 @@ compiler_lambda(struct compiler *c, expr_ty e)
+@@ -1529,7 +1614,7 @@ compiler_lambda(struct compiler *c, expr_ty e)
      if (co == NULL)
          return 0;
  
@@ -2427,7 +2427,7 @@ index 8354c75..a81813c 100644
      Py_DECREF(co);
  
      return 1;
-@@ -2366,6 +2451,7 @@ compiler_nameop(struct compiler *c, identifier name, expr_context_ty ctx)
+@@ -2328,6 +2413,7 @@ compiler_nameop(struct compiler *c, identifier name, expr_context_ty ctx)
      op = 0;
      optype = OP_NAME;
      scope = PyST_GetScope(c->u->u_ste, mangled);
@@ -2435,21 +2435,21 @@ index 8354c75..a81813c 100644
      switch (scope) {
      case FREE:
          dict = c->u->u_freevars;
-@@ -2530,6 +2616,13 @@ compiler_tuple(struct compiler *c, expr_ty e)
+@@ -2490,6 +2576,13 @@ compiler_tuple(struct compiler *c, expr_ty e)
+     return 1;
  }
  
- static int
++static int
 +compiler_ellipsis(struct compiler *c, expr_ty e)
 +{
 +    ADDOP_O(c, LOAD_CONST, Py_Ellipsis, consts);
 +    return 1;
 +}
 +
-+static int
+ static int
  compiler_compare(struct compiler *c, expr_ty e)
  {
-     int i, n;
-@@ -2820,7 +2913,7 @@ compiler_comprehension(struct compiler *c, expr_ty e, int type, identifier name,
+@@ -2781,7 +2874,7 @@ compiler_comprehension(struct compiler *c, expr_ty e, int type, identifier name,
      if (co == NULL)
          goto error;
  
@@ -2458,7 +2458,7 @@ index 8354c75..a81813c 100644
          goto error;
      Py_DECREF(co);
  
-@@ -3132,6 +3225,8 @@ compiler_visit_expr(struct compiler *c, expr_ty e)
+@@ -3093,6 +3186,8 @@ compiler_visit_expr(struct compiler *c, expr_ty e)
          return compiler_list(c, e);
      case Tuple_kind:
          return compiler_tuple(c, e);
@@ -2467,7 +2467,7 @@ index 8354c75..a81813c 100644
      }
      return 1;
  }
-@@ -3361,9 +3456,6 @@ compiler_visit_nested_slice(struct compiler *c, slice_ty s,
+@@ -3322,9 +3417,6 @@ compiler_visit_nested_slice(struct compiler *c, slice_ty s,
                              expr_context_ty ctx)
  {
      switch (s->kind) {
@@ -2477,7 +2477,7 @@ index 8354c75..a81813c 100644
      case Slice_kind:
          return compiler_slice(c, s, ctx);
      case Index_kind:
-@@ -3389,12 +3481,6 @@ compiler_visit_slice(struct compiler *c, slice_ty s, expr_context_ty ctx)
+@@ -3350,12 +3442,6 @@ compiler_visit_slice(struct compiler *c, slice_ty s, expr_context_ty ctx)
              VISIT(c, expr, s->v.Index.value);
          }
          break;
@@ -2491,7 +2491,7 @@ index 8354c75..a81813c 100644
          kindname = "slice";
          if (!s->v.Slice.step)
 diff --git a/Python/future.c b/Python/future.c
-index 0e68845..4a7365d 100644
+index 0e68845981..4a7365d479 100644
 --- a/Python/future.c
 +++ b/Python/future.c
 @@ -39,6 +39,8 @@ future_check_features(PyFutureFeatures *ff, stmt_ty s, const char *filename)
@@ -2504,7 +2504,7 @@ index 0e68845..4a7365d 100644
              PyErr_SetString(PyExc_SyntaxError,
                              "not a chance");
 diff --git a/Python/graminit.c b/Python/graminit.c
-index 5db6bb5..724940a 100644
+index 5db6bb5e53..724940a951 100644
 --- a/Python/graminit.c
 +++ b/Python/graminit.c
 @@ -113,28 +113,37 @@ static arc arcs_6_1[1] = {
@@ -5855,10 +5855,10 @@ index 5db6bb5..724940a 100644
      256
  };
 diff --git a/Python/pythonrun.c b/Python/pythonrun.c
-index 2a40c0b..cb513ae 100644
+index 5707c9f524..4151ce596b 100644
 --- a/Python/pythonrun.c
 +++ b/Python/pythonrun.c
-@@ -79,6 +79,7 @@ int Py_InteractiveFlag; /* Needed by Py_FdIsInteractive() below */
+@@ -71,6 +71,7 @@ int Py_InteractiveFlag; /* Needed by Py_FdIsInteractive() below */
  int Py_InspectFlag; /* Needed to determine whether to exit at SystemExit */
  int Py_NoSiteFlag; /* Suppress 'import site' */
  int Py_BytesWarningFlag; /* Warn on str(bytes) and str(buffer) */
@@ -5866,7 +5866,7 @@ index 2a40c0b..cb513ae 100644
  int Py_DontWriteBytecodeFlag; /* Suppress writing bytecode files (*.py[co]) */
  int Py_UseClassExceptionsFlag = 1; /* Needed by bltinmodule.c: deprecated */
  int Py_FrozenFlag; /* Needed by getpath.c */
-@@ -800,6 +801,8 @@ PyRun_InteractiveLoopFlags(FILE *fp, const char *filename, PyCompilerFlags *flag
+@@ -809,6 +810,8 @@ PyRun_InteractiveLoopFlags(FILE *fp, const char *filename, PyCompilerFlags *flag
                     PyPARSE_PRINT_IS_FUNCTION : 0) \
                  | (((flags)->cf_flags & CO_FUTURE_UNICODE_LITERALS) ? \
                     PyPARSE_UNICODE_LITERALS : 0) \
@@ -5876,10 +5876,10 @@ index 2a40c0b..cb513ae 100644
  #endif
  
 diff --git a/Python/symtable.c b/Python/symtable.c
-index 644d9c5..a54be16 100644
+index 21790b1cd1..7401a063b2 100644
 --- a/Python/symtable.c
 +++ b/Python/symtable.c
-@@ -1006,6 +1006,19 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
+@@ -1012,6 +1012,19 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
              return 0;
          if (s->v.FunctionDef.args->defaults)
              VISIT_SEQ(st, expr, s->v.FunctionDef.args->defaults);
@@ -5899,7 +5899,7 @@ index 644d9c5..a54be16 100644
          if (s->v.FunctionDef.decorator_list)
              VISIT_SEQ(st, expr, s->v.FunctionDef.decorator_list);
          if (!symtable_enter_block(st, s->v.FunctionDef.name,
-@@ -1266,6 +1279,7 @@ symtable_visit_expr(struct symtable *st, expr_ty e)
+@@ -1272,6 +1285,7 @@ symtable_visit_expr(struct symtable *st, expr_ty e)
          break;
      case Num_kind:
      case Str_kind:
@@ -5907,7 +5907,7 @@ index 644d9c5..a54be16 100644
          /* Nothing to do here. */
          break;
      /* The following exprs can be assignment targets. */
-@@ -1470,8 +1484,6 @@ symtable_visit_slice(struct symtable *st, slice_ty s)
+@@ -1475,8 +1489,6 @@ symtable_visit_slice(struct symtable *st, slice_ty s)
      case Index_kind:
          VISIT(st, expr, s->v.Index.value)
          break;


### PR DESCRIPTION
It can now be applied cleanly to CPython 2.7 HEAD.

Tested by applying the patch on the current 2.7 HEAD and getting a clean
run of the CPython test suite.