### PR TITLE
Support excluding files or directories from analyze_project.

### DIFF
--- a/pytype/tools/analyze_project/main.py
+++ b/pytype/tools/analyze_project/main.py
@@ -65,8 +65,7 @@ def main():
   logging.info('\n  '.join(['Configuration:'] + str(conf).split('\n')))
 
   if not args.inputs:
-    parser.parser.print_usage()
-    sys.exit(0)
+    parser.parser.error('Need an input.')
 
   # Importlab needs the python exe, so we check it as early as possible.
   environment.check_python_exe_or_die(conf.python_version)

--- a/pytype/tools/analyze_project/parse_args.py
+++ b/pytype/tools/analyze_project/parse_args.py
@@ -97,8 +97,11 @@ def make_parser():
 
   parser = argparse.ArgumentParser(usage='%(prog)s [options] input [input ...]')
   parser.add_argument(
-      'filenames', metavar='input', type=str, nargs='*',
+      'inputs', metavar='input', type=str, nargs='*',
       help='file or directory to process')
+  parser.add_argument(
+      '--exclude', dest='exclude', type=str, nargs='*',
+      help='comma-separated list of files or directories to exclude')
   modes = parser.add_mutually_exclusive_group()
   modes.add_argument(
       '--tree', dest='tree', action='store_true', default=False,

--- a/pytype/tools/analyze_project/parse_args_test.py
+++ b/pytype/tools/analyze_project/parse_args_test.py
@@ -31,7 +31,12 @@ class TestParser(unittest.TestCase):
   def test_parse_filenames(self):
     filenames = ['a.py', 'b.py']
     args = self.parser.parse_args(filenames)
-    self.assertSequenceEqual(args.filenames, filenames)
+    self.assertSequenceEqual(args.inputs, filenames)
+
+  def test_parse_exclude(self):
+    exclude = ['--exclude', 'a.py', 'b.py']
+    args = self.parser.parse_args(exclude)
+    self.assertSequenceEqual(args.exclude, ['a.py', 'b.py'])
 
   def test_verbosity(self):
     self.assertEqual(self.parser.parse_args(['--verbosity', '0']).verbosity, 0)


### PR DESCRIPTION
* Supports an --exclude flag to make it easy to exclude parts of
  a directory that are not pytype-safe (e.g.,
  `pytype subpackage --exclude subpackage/*_test.py`)
* Renames the filenames arg to inputs in preparation for adding
  it to the configuration file, since `filenames` is a bit of a
  misnomer when we allow directories as well.

This PR will have to be imported into Google and then re-exported.