### PR TITLE
Dogfood open-source pytype.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,19 @@ before_install:
 install:
   - pip install pyyaml
   - pip install six
+  - pip install pytype
 
-# We pass the -f option so that the script aborts at the first
+# Before testing the code, "compile" it by statically analyzing the types.
+# TODO(rechen): Support specifying the pytype inputs in setup.cfg instead.
+# Due to https://github.com/travis-ci/travis-ci/issues/1066, if we want
+# the build to stop on pytype failure, we have to use one large command.
+# We pass the -f option to run_tests so that the script aborts at the first
 # failure and gives a less cluttered output.
-script: python build_scripts/run_tests.py -f
+script: |
+  pytype\
+    pytype/compat.py pytype/debug.py pytype/utils.py pytype/pyc\
+    --exclude pytype/pyc/*_test.py &&
+  python build_scripts/run_tests.py -f
 
 notifications:
   email:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytype]
+python_version = 2.7


### PR DESCRIPTION
The motivation for this change is to have a working example of running pytype on a GitHub project that we can point to when recruiting early adopters. Also, dogfooding is good.

For now, I've piggy-backed on Travis as the easiest way to get this
set up. Pytype failures will be reported as build failures.

This PR can be merged directly, since it doesn't touch any internal files.