### PR TITLE
Add cpython submodule pinned to the current 2.7 HEAD.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "googletest"]
 	path = googletest
 	url = https://github.com/google/googletest
+[submodule "cpython"]
+	path = cpython
+	url = https://github.com/python/cpython.git

--- a/build_scripts/build.py
+++ b/build_scripts/build.py
@@ -10,8 +10,10 @@ Specifying the -c option forces a clobber before building.
 from __future__ import print_function
 
 import argparse
+import sys
 
 import build_utils
+import py27
 
 def parse_args():
   parser = argparse.ArgumentParser()
@@ -19,6 +21,9 @@ def parse_args():
                       help="Force clobber before building.")
   parser.add_argument("--debug", "-d", action="store_true", default=False,
                       help="Build targets in the debug mode.")
+  parser.add_argument(
+      "--py27", action="store_true", default=False,
+      help="Build Python-2.7 interpreter with type annotation patch applied.")
   return parser.parse_args()
 
 
@@ -26,11 +31,13 @@ def main():
   options = parse_args()
   if not build_utils.run_cmake(force_clean=options.clobber, log_output=True,
                                debug_build=options.debug):
-    return 1
+    sys.exit(1)
   print("Building all targets with Ninja ...\n")
   if not build_utils.run_ninja(["all"], fail_fast=True):
-    return 1
-  print("Build successful!\n")
+    sys.exit(1)
+  print("Pytype built successfully!\n")
+  if options.py27:
+    sys.exit(py27.build_backported_interpreter(options.clobber))
 
 
 if __name__ == "__main__":

--- a/build_scripts/build_utils.py
+++ b/build_scripts/build_utils.py
@@ -77,14 +77,19 @@ class BuildConfig(object):
       return BuildConfig(**{})
 
 
-def _clean_out_dir(msg):
-  print(msg)
-  for item in os.listdir(OUT_DIR):
-    path = os.path.join(OUT_DIR, item)
+def clean_dir(dir_path, exclude_file_list=None):
+  exclude_list = exclude_file_list or []
+  for item in os.listdir(dir_path):
+    path = os.path.join(dir_path, item)
     if os.path.isdir(path):
       shutil.rmtree(path)
-    elif item not in ["README.md", ".gitignore"]:
+    elif item not in exclude_list:
       os.remove(path)
+
+
+def _clean_out_dir(msg):
+  print(msg)
+  clean_dir(OUT_DIR, ["README.md", ".gitignore"])
 
 
 def parse_ninja_output_line(line):

--- a/build_scripts/py27.py
+++ b/build_scripts/py27.py
@@ -1,0 +1,86 @@
+"""Utils to build Python-2.7 interpreter with type annotations backported.
+"""
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+
+import build_utils
+
+_BUILD_DIR = os.path.join(build_utils.OUT_DIR, "python27_build")
+_INSTALL_DIR = os.path.join(build_utils.OUT_DIR, "python27")
+_CPYTHON_SRC_DIR = os.path.join(build_utils.PYTYPE_SRC_ROOT, "cpython")
+
+
+def _parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--clobber", "-c", action="store_true", default=False,
+                      help="Force clobber before building.")
+  return parser.parse_args()
+
+
+def _prepare_directories(clobber):
+  if not os.path.exists(_BUILD_DIR):
+    os.makedirs(_BUILD_DIR)
+  if not os.path.exists(_INSTALL_DIR):
+    os.makedirs(_INSTALL_DIR)
+  if clobber:
+    build_utils.clean_dir(_BUILD_DIR)
+    build_utils.clean_dir(_INSTALL_DIR)
+
+
+def _apply_patch():
+  patch_file = os.path.join(build_utils.PYTYPE_SRC_ROOT, "2.7_patches",
+                            "python_2_7_type_annotations.diff")
+  return build_utils.run_cmd(["git", "apply", patch_file], cwd=_CPYTHON_SRC_DIR)
+
+
+def _revert_patch():
+  return build_utils.run_cmd(["git", "checkout", "--", "."],
+                             cwd=_CPYTHON_SRC_DIR)
+
+
+def _configure_build():
+  config_script = os.path.join(_CPYTHON_SRC_DIR, "configure")
+  return build_utils.run_cmd([config_script, "--prefix=%s" % _INSTALL_DIR],
+                             cwd=_BUILD_DIR)
+
+
+def _build():
+  return build_utils.run_cmd(["make", "-j16"], cwd=_BUILD_DIR)
+
+
+def _install():
+  return build_utils.run_cmd(["make", "install"], cwd=_BUILD_DIR)
+
+
+def build_backported_interpreter(clobber=False):
+  print("Building Python-2.7 interpreter...\n")
+  _prepare_directories(clobber)
+  task_list = [
+    (_apply_patch, "Applying type annotations patch"),
+    ( _configure_build, "Configuring CPython build"),
+    ( _build, "Building patched CPython interpreter"),
+    ( _install, "Installing the CPython interpreter"),
+    ( _revert_patch, "Reverting type annotations patch"),
+  ]
+  for task, task_info in task_list:
+    print("Python-2.7 build step: %s... " % task_info, end='')
+    returncode, stdout = task()
+    if returncode != 0:
+      print("FAILED\n" % task_info)
+      return returncode
+    print("DONE")
+  print("")  # An empty line at the end of successfull build.
+  print("Python-2.7 interpreter built succesfully!\n")
+  return 0
+
+
+def main():
+  options = _parse_args()
+  sys.exit(build_backported_interpreter(options.clobber))
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Extended the build script to build the patched Python2.7 interpreter if
the option "--py27" is specified. A standalone script which can build
the patched interpreter has also been added. This script will be used by
a CMake target to build the patched interpreter as part of the
run_tests.py flow.