### PR TITLE
Future-proof preconditions.py:_TOKEN_RE

### DIFF
--- a/pytype/pytd/parse/preconditions.py
+++ b/pytype/pytd/parse/preconditions.py
@@ -163,7 +163,7 @@ class CallChecker(object):
 
 # RE to match a single token.  Leading whitepace is ignored.
 _TOKEN_RE = re.compile(
-    r"\s*(?:(?P<literal>[[\]{}])|(?P<word>[a-zA-Z_]\w*))")
+    r"\s*(?:(?P<literal>[\[\]{}])|(?P<word>[a-zA-Z_]\w*))")
 
 # Token codes (aside from literal characters)
 _TOKEN_NAME = 1


### PR DESCRIPTION
3.7 adds a warning about possible future changes to re: https://bugs.python.org/issue30349
A future version of python will add nested sets, which allows nesting of sets using `[...]`. Escape the inner `[` in the re so it doesn't trigger a nested set.
Closes #140.