### PR TITLE
Add partial support for nested classes in pyi files.

### DIFF
--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2018.8.10'
+__version__ = '2018.9.7'

--- a/pytype/pyi/parser.h
+++ b/pytype/pyi/parser.h
@@ -32,11 +32,11 @@ enum CallSelector {
   kAddImport,
   kAddAliasOrConstant,
   kNewAliasOrConstant,
+  kNewClass,
   kNewConstant,
   kNewFunction,
   kNewNamedTuple,
   kRegisterClassName,
-  kAddClass,
   kAddTypeVar,
 
   kIfBegin,

--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -942,8 +942,8 @@ class _Parser(object):
           Parent types must be instances of pytd.Type.  Keyword tuples must
           appear at the end of the list.  Currently the only supported keyword
           is 'metaclass'.
-      defs: A list of constant (pytd.Constant) and function (_NameAndSig)
-          definitions.
+      defs: A list of constant (pytd.Constant), function (_NameAndSig), alias
+          (pytd.Alias), slot (_SlotDecl), and class (pytd.Class) definitions.
 
     Returns:
       None if the class definition is inside a non-active conditional,

--- a/pytype/pyi/parser.yy
+++ b/pytype/pyi/parser.yy
@@ -147,7 +147,7 @@ alldefs
       CHECK(tmp, @$);
       Py_DECREF(tmp);
     }
-  | alldefs classdef { $$ = $1; Py_DECREF($2); }
+  | alldefs classdef { $$ = AppendList($1, $2); }
   | alldefs typevardef { $$ = $1; Py_DECREF($2); }
   | alldefs if_stmt {
       PyObject* tmp = ctx->Call(kIfEnd, "(N)", $2);
@@ -161,9 +161,12 @@ maybe_type_ignore
   : typeignore
   |
 
+/* TODO(rechen): maybe_class_funcs contains all class attributes, not just
+ * functions; rename it to something less confusing.
+ */
 classdef
   : CLASS class_name parents ':' maybe_type_ignore maybe_class_funcs {
-      $$ = ctx->Call(kAddClass, "(NNN)", $2, $3, $6);
+      $$ = ctx->Call(kNewClass, "(NNN)", $2, $3, $6);
       CHECK($$, @$);
     }
   ;
@@ -219,6 +222,7 @@ funcdefs
       CHECK(tmp, @2);
       $$ = ExtendList($1, tmp);
     }
+  | funcdefs classdef { $$ = AppendList($1, $2); }
   | /* EMPTY */ { $$ = PyList_New(0); }
   ;
 

--- a/pytype/pyi/parser_ext.cc
+++ b/pytype/pyi/parser_ext.cc
@@ -43,11 +43,11 @@ static const SelectorEntry<CallSelector> call_attributes[] = {
   {kAddImport, "add_import"},
   {kAddAliasOrConstant, "add_alias_or_constant"},
   {kNewAliasOrConstant, "new_alias_or_constant"},
+  {kNewClass, "new_class"},
   {kNewConstant, "new_constant"},
   {kNewFunction, "new_function"},
   {kNewNamedTuple, "new_named_tuple"},
   {kRegisterClassName, "register_class_name"},
-  {kAddClass, "add_class"},
   {kAddTypeVar, "add_type_var"},
 
   {kIfBegin, "if_begin"},

--- a/pytype/pyi/parser_test.py
+++ b/pytype/pyi/parser_test.py
@@ -232,6 +232,15 @@ class ParserTest(_ParserTestBase):
           __slots__ = ["foo", ?]
     """, 1, "Entries in __slots__ can only be strings")
 
+  def test_nested_class(self):
+    self.check("""\
+      class A:
+          class B: ...
+    """, """\
+      class A:
+          B = ...  # type: type
+    """)
+
   def test_import(self):
     self.check("import foo.bar.baz", "")
     self.check("import a as b")
@@ -1301,11 +1310,14 @@ class ClassIfTest(_ParserTestBase):
     """, 1, "Illegal value for alias 'a'")
 
   def test_no_class(self):
-    self.check_error("""\
+    self.check("""\
       class Foo:
-        if sys.version_info > (2, 7, 0):
+        if sys.version_info <= (2, 7, 0):
           class Bar: ...
-    """, 3, "syntax error")
+    """, """\
+      class Foo:
+          pass
+    """)
 
   def test_no_typevar(self):
     self.check_error("""\


### PR DESCRIPTION
This PR will have to be imported and re-exported rather than merged directly.

It attempts to resolve https://github.com/google/pytype/issues/134 by fixing the second issue that prevented pytype from parsing the yaml pyi files, the existence of a nested class in yaml.constructor. I decided to change our parser rather than typeshed because I found more examples of nested classes in typeshed/third_party/2and3/google/protobuf/.

I'm not yet calling the issue fixed because I still want to do a release (hence the `__version__` change), verify the fix, and then change typeshed's pytype_test to cover yaml/ going forward.