### PR TITLE
Remove custom email notification settings from .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,3 @@ install:
   - pip install six
 
 script: python build_scripts/travis_script.py
-
-notifications:
-  email:
-    recipients:
-      - pytype@googlegroups.com
-    on_success: change
-    on_failure: always


### PR DESCRIPTION
Based on my reading of https://docs.travis-ci.com/user/notifications/,
I believe that without the custom settings, the email frequency will be
the same, but the emails will be sent to the PR author (if the author
is a member of the pytype repo). This seems good enough to me and will
stop our spamming of the external mailing list.

Fixes #185.