### PR TITLE
Have pytype (naively) generate ninja files.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,5 @@
+Version (upcoming)
+* Generate a build.ninja file and call pytype-single via ninja.
+
+Version 2018.10.30
+* Improve the display of tracebacks in error messages.

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup(
     package_data={'pytype': get_builtin_files()},
     install_requires=[
         'importlab',
+        'ninja',
         'pyyaml (>=3.11)',
         'six'
     ],


### PR DESCRIPTION
Has pytype farm its pytype-single calls out to ninja via subprocess. At the end
of the change description, I've included a short explanation of how ninja works;
for more detail, there's https://ninja-build.org/manual.html.

I've called this change "naive" because it does not:
(1) avoid clearing pytype_output/ so that output can be reused between runs or
(2) generate fine-grained dependency info so that ninja can parallelize builds.
These improvements will be in future CLs.

Makes progress toward #173. Fixes #169.

* Adds this change to a new CHANGELOG file. We discussed starting a changelog
  in the meeting, so we might as well start now. I've added a single entry for
  the most recent release, to show how the file will be structured; I'll
  backfill the rest of the file later.
* Adds ninja to install_requires in setup.py.
* Moves pyi files into a subdirectory of pytype_output/ so we can have two
  pyi dirs, `pyi` and `pyi_1`.
* Adds a write_ninja_preamble method, which writes out the pytype-single rules
  to build.ninja.
* Adds a write_build_statement method, which appends a single build statement
  to build.ninja.
* Adds a setup_build method, which writes out a full build.ninja file using the
  above two helpers. This method differs in two main ways from the old loop
  over yield_sorted_modules() in PytypeRunner.run(): it skips useless actions,
  and it doesn't count builtin and system files in the progress message. The
  second change was made so that pytype's file count would be more in line
  with ninja's action count.
* Adds a build method, which calls out to ninja via subprocess.

How ninja works:

ninja looks for a build.ninja containing a number of rules and build statements.
For example:

rule infer
  command = pytype-single -o $out $in
build foo.pyi: infer foo.py
build bar.pyi: infer bar.py | foo.pyi

defines an `infer` rule and statements to build `foo.pyi` and `bar.pyi`. In the
second build statement, `| foo.pyi` says that bar.pyi depends on foo.pyi. ninja
will ensure both foo.pyi and bar.pyi are present and up-to-date by executing any
build statements necessary.

The variables $out and $in are provided by default; it's also easy to define
custom ones:

rule infer
  command = pytype-single -P $pythonpath -o $out $in
build foo.pyi: infer foo.py
  pythonpath = pytype_output/pyi/

TESTED=new and existing unit tests, plus pip installing pytype with this change
and running it over some GitHub repos.
PiperOrigin-RevId: 219702660