### PR TITLE
Add testing framework for target Python 3.7.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Version (upcoming)
+* Add testing framework for target Python 3.7.
+
 Version 2018.12.11
 * Add rudimentary support for target Python 3.7.
 * Make error messages for Python operators friendlier.

--- a/pytype/abstract.py
+++ b/pytype/abstract.py
@@ -695,9 +695,10 @@ class SimpleAbstractValue(AtomicAbstractValue):
     if self.cls:
       key.add(self.cls)
     for name, var in self.instance_type_parameters.items():
-      subkey = frozenset(value.data.get_default_type_key() if value.data in seen
-                         else value.data.get_type_key(seen)
-                         for value in var.bindings)
+      subkey = frozenset(
+          value.data.get_default_type_key()  # pylint: disable=g-long-ternary
+          if value.data in seen else value.data.get_type_key(seen)
+          for value in var.bindings)
       key.add((name, subkey))
     if key:
       type_key = frozenset(key)

--- a/pytype/abstract.py
+++ b/pytype/abstract.py
@@ -3307,7 +3307,10 @@ class BuildClass(AtomicAbstractValue):
 
   def call(self, node, _, args, alias_map=None):
     funcvar, name = args.posargs[0:2]
-    kwargs = args.namedargs.pyval
+    if isinstance(args.namedargs, dict):
+      kwargs = args.namedargs
+    else:
+      kwargs = self.vm.convert.value_to_constant(args.namedargs, dict)
     # TODO(mdemello): Check if there are any changes between python2 and
     # python3 in the final metaclass computation.
     # TODO(mdemello): Any remaining kwargs need to be passed to the metaclass.

--- a/pytype/config_test.py
+++ b/pytype/config_test.py
@@ -1,10 +1,10 @@
 """Tests for config.py."""
 
-import subprocess
 import sys
 
 from pytype import config
 from pytype import datatypes
+from pytype.tests import test_utils
 
 import unittest
 
@@ -61,17 +61,10 @@ class ConfigTest(unittest.TestCase):
     ]:
       self._test_arg_conflict(arg1, arg2)
 
-  # TODO(rechen): Remove this hack once python3.7 is available in all of
-  # pytype's testing environments.
-  try:
-    subprocess.call(["python3.7", "-V"])
-  except OSError:
-    pass
-  else:
-    # pylint: disable=g-wrong-blank-lines
-    def test_v37(self):
-      opts = config.Options(["-V3.7", "test.py"])
-      self.assertEqual(opts.python_version, (3, 7))
+  @test_utils.skipUnless37Available
+  def test_v37(self):
+    opts = config.Options(["-V3.7", "test.py"])
+    self.assertEqual(opts.python_version, (3, 7))
 
 
 class PostprocessorTest(unittest.TestCase):

--- a/pytype/pyc/compile_bytecode.py
+++ b/pytype/pyc/compile_bytecode.py
@@ -2,12 +2,18 @@
 
 # These are C modules built into Python. Don't add any modules that are
 # implemented in a .py:
-import imp
 import marshal
 import re
 import sys
 
-MAGIC = imp.get_magic()
+# pylint: disable=g-import-not-at-top
+if sys.version_info[0] == 2:
+  import imp
+  MAGIC = imp.get_magic()
+else:
+  import importlib.util
+  MAGIC = importlib.util.MAGIC_NUMBER
+# pylint: enable=g-import-not-at-top
 
 # This pattern is as per PEP-263.
 ENCODING_PATTERN = "^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)"

--- a/pytype/tests/README.md
+++ b/pytype/tests/README.md
@@ -16,23 +16,23 @@ The tests in this directory are grouped into three logical buckets:
 directory. They do not depend on any specific feature from the target's version.
 They also should not use type annotations in the target code. The test classes
 for these tests are subclasses of `TargetIndependentTest`. These tests are
-run twice, once with target version set to 2.7, and another time with target
-version set to 3.6.
+run multiple times, once with target version set to 2.7, and another time per
+target Python 3 version supported.
 
-2. The 2.7 Feature Bucket: Tests of this kind live in the `py2`
+2. The Py2 Feature Bucket: Tests of this kind live in the `py2`
 subdirectory. The target code for these tests uses a Python 2.7 specific
 feature. The test classes for these tests are subclasses of
 `TargetPython27FeatureTest`.
 
-3. The 3.6 Basic Bucket: Tests of this kind live in the `py3` subdirectory.
+3. The Py3 Basic Bucket: Tests of this kind live in the `py3` subdirectory.
 The target code for these tests uses type annotations as the only Python 3
 specific feature. Without the type annotations, the target should be version
 agnostic. The test classes for these tests are subclasses of
 `TargetPython3BasicTest`.
 
-4. The 3.6 Feature Bucket: Tests of this kind also live in the `py3`
-subdirectory. The target code for these tests uses a Python 3.6 specific
-feature, with or without type annotations. The test classes for these tests are
+4. The Py3 Feature Bucket: Tests of this kind also live in the `py3`
+subdirectory. The target code for these tests uses a Python 3 specific feature,
+with or without type annotations. The test classes for these tests are
 subclasses of `TargetPython3FeatureTest`.
 
 ## Adding New Tests

--- a/pytype/tests/py3/test_stdlib.py
+++ b/pytype/tests/py3/test_stdlib.py
@@ -234,6 +234,8 @@ class StdlibTestsFeatures(test_base.TargetPython3FeatureTest,
       v = ...  # type: int
     """)
 
+  @test_utils.skipInVersion(
+      (3, 7), "https://github.com/google/pytype/issues/203")
   def test_async(self):
     """Test various asyncio features."""
     ty = self.Infer("""
@@ -271,6 +273,8 @@ class StdlibTestsFeatures(test_base.TargetPython3FeatureTest,
       def test_with(x) -> None: ...
     """)
 
+  @test_utils.skipInVersion(
+      (3, 7), "https://github.com/google/pytype/issues/203")
   def test_async_iter(self):
     ty = self.Infer("""
       import asyncio

--- a/pytype/tests/py3/test_stdlib.py
+++ b/pytype/tests/py3/test_stdlib.py
@@ -234,8 +234,7 @@ class StdlibTestsFeatures(test_base.TargetPython3FeatureTest,
       v = ...  # type: int
     """)
 
-  @test_utils.skipInVersion(
-      (3, 7), "https://github.com/google/pytype/issues/203")
+  @test_utils.skipIn37("https://github.com/google/pytype/issues/203")
   def test_async(self):
     """Test various asyncio features."""
     ty = self.Infer("""
@@ -273,8 +272,7 @@ class StdlibTestsFeatures(test_base.TargetPython3FeatureTest,
       def test_with(x) -> None: ...
     """)
 
-  @test_utils.skipInVersion(
-      (3, 7), "https://github.com/google/pytype/issues/203")
+  @test_utils.skipIn37("https://github.com/google/pytype/issues/203")
   def test_async_iter(self):
     ty = self.Infer("""
       import asyncio

--- a/pytype/tests/py3/test_variable_annotations.py
+++ b/pytype/tests/py3/test_variable_annotations.py
@@ -36,8 +36,7 @@ class VariableAnnotationsBasicTest(test_base.TargetPython3BasicTest):
 class VariableAnnotationsFeatureTest(test_base.TargetPython3FeatureTest):
   """Tests for PEP526 variable annotations."""
 
-  @test_utils.skipInVersion(
-      (3, 7), "https://github.com/google/pytype/issues/216")
+  @test_utils.skipIn37("https://github.com/google/pytype/issues/216")
   def testInferTypes(self):
     ty = self.Infer("""\
       from typing import List
@@ -64,8 +63,7 @@ class VariableAnnotationsFeatureTest(test_base.TargetPython3FeatureTest):
           b: int
     """)
 
-  @test_utils.skipInVersion(
-      (3, 7), "https://github.com/google/pytype/issues/216")
+  @test_utils.skipIn37("https://github.com/google/pytype/issues/216")
   def testIllegalAnnotations(self):
     _, errors = self.InferWithErrors("""\
       from typing import List, TypeVar, NoReturn

--- a/pytype/tests/py3/test_variable_annotations.py
+++ b/pytype/tests/py3/test_variable_annotations.py
@@ -2,6 +2,7 @@
 
 from pytype import file_utils
 from pytype.tests import test_base
+from pytype.tests import test_utils
 
 
 class VariableAnnotationsBasicTest(test_base.TargetPython3BasicTest):
@@ -35,6 +36,8 @@ class VariableAnnotationsBasicTest(test_base.TargetPython3BasicTest):
 class VariableAnnotationsFeatureTest(test_base.TargetPython3FeatureTest):
   """Tests for PEP526 variable annotations."""
 
+  @test_utils.skipInVersion(
+      (3, 7), "https://github.com/google/pytype/issues/216")
   def testInferTypes(self):
     ty = self.Infer("""\
       from typing import List
@@ -61,6 +64,8 @@ class VariableAnnotationsFeatureTest(test_base.TargetPython3FeatureTest):
           b: int
     """)
 
+  @test_utils.skipInVersion(
+      (3, 7), "https://github.com/google/pytype/issues/216")
   def testIllegalAnnotations(self):
     _, errors = self.InferWithErrors("""\
       from typing import List, TypeVar, NoReturn

--- a/pytype/tests/test_base.py
+++ b/pytype/tests/test_base.py
@@ -573,14 +573,13 @@ def _ReplaceAttribute(test_case, versions, attr_name):
   for v in versions:
     method = _ReplacementMethod(v, attr)
     pytype_skip = getattr(attr, "__pytype_skip__", None)
-    if pytype_skip and pytype_skip[0] == v:
-      # test_utils.skipInVersion sets __pytype_skip__ to a tuple of
-      # (version, reason) to indicate that a test should be skipped in the given
-      # version for the specified reason.
-      method = skip(pytype_skip[1])(method)
-    elif v == (3, 7):
-      # Hack to work around 3.7 being unavailable in some testing environments.
-      method = test_utils.skipUnless37Available(method)
+    if v == (3, 7):
+      if pytype_skip:
+        # test_utils.skipIn37 sets __pytype_skip__ to the reason for skipping.
+        method = skip(pytype_skip)(method)
+      else:
+        # Hack to work around 3.7 unavailability in some testing environments.
+        method = test_utils.skipUnless37Available(method)
     setattr(test_case, "%s_py%d%d" % ((attr_name,) + v), method)
   delattr(test_case, attr_name)
 

--- a/pytype/tests/test_base.py
+++ b/pytype/tests/test_base.py
@@ -572,7 +572,13 @@ def _ReplaceAttribute(test_case, versions, attr_name):
     return
   for v in versions:
     method = _ReplacementMethod(v, attr)
-    if v == (3, 7):
+    pytype_skip = getattr(attr, "__pytype_skip__", None)
+    if pytype_skip and pytype_skip[0] == v:
+      # test_utils.skipInVersion sets __pytype_skip__ to a tuple of
+      # (version, reason) to indicate that a test should be skipped in the given
+      # version for the specified reason.
+      method = skip(pytype_skip[1])(method)
+    elif v == (3, 7):
       # Hack to work around 3.7 being unavailable in some testing environments.
       method = test_utils.skipUnless37Available(method)
     setattr(test_case, "%s_py%d%d" % ((attr_name,) + v), method)

--- a/pytype/tests/test_base.py
+++ b/pytype/tests/test_base.py
@@ -18,6 +18,7 @@ from pytype.pytd import pytd
 from pytype.pytd import pytd_utils
 from pytype.pytd import serialize_ast
 from pytype.pytd import visitors
+from pytype.tests import test_utils
 
 import unittest
 
@@ -538,17 +539,44 @@ def _ReplacementMethod(python_version, actual_method):
   return Replacement
 
 
-def _ReplaceMethods(toplevel):
+def _GetTargetVersions(toplevel):
+  """Maybe return a list of target versions.
+
+  Arguments:
+    toplevel: the top-level module object.
+
+  Returns:
+    None if toplevel is not a test class or doesn't need to test under at least
+    two versions. Otherwise a list of (major, minor) versions.
+  """
   if not isinstance(toplevel, type):
-    return False
+    return None
   if issubclass(toplevel, TargetIndependentTest):
-    return True
-  # Run the Python 3 basic tests with target Python version set to 2.7 if we
-  # can use type annotations in 2.7.
-  if (utils.USE_ANNOTATIONS_BACKPORT and
-      issubclass(toplevel, TargetPython3BasicTest)):
-    return not issubclass(toplevel, TargetPython3FeatureTest)
-  return False
+    return [(2, 7), (3, 6), (3, 7)]
+  elif issubclass(toplevel, TargetPython3FeatureTest):
+    return [(3, 6), (3, 7)]
+  elif issubclass(toplevel, TargetPython3BasicTest):
+    if utils.USE_ANNOTATIONS_BACKPORT:
+      # Run the Python 3 basic tests with target Python version set to 2.7 if we
+      # can use type annotations in 2.7.
+      return [(2, 7), (3, 6), (3, 7)]
+    else:
+      return [(3, 6), (3, 7)]
+  else:
+    return None
+
+
+def _ReplaceAttribute(test_case, versions, attr_name):
+  attr = getattr(test_case, attr_name)
+  if not attr_name.startswith("test") or not callable(attr):
+    return
+  for v in versions:
+    method = _ReplacementMethod(v, attr)
+    if v == (3, 7):
+      # Hack to work around 3.7 being unavailable in some testing environments.
+      method = test_utils.skipUnless37Available(method)
+    setattr(test_case, "%s_py%d%d" % ((attr_name,) + v), method)
+  delattr(test_case, attr_name)
 
 
 def main(toplevels, is_main_module=True):
@@ -567,19 +595,13 @@ def main(toplevels, is_main_module=True):
     is_main_module: True if the main test module is the main module in the
                     interpreter.
   """
-  # We want to run tests in a few buckets twice: once with target Python
-  # version set to 2.7, and another time with target Python version set to 3.6.
+  # We want to run tests in a few buckets under multiple target Python versions.
   # So, for tests falling in such buckets, we replace the single test method
-  # with two methods, one each for the target version 2.7 and 3.6 respectively.
+  # with multiple methods, one for each target version.
   for _, tp in toplevels.items():
-    if _ReplaceMethods(tp):
+    versions = _GetTargetVersions(tp)
+    if versions:
       for attr_name in dir(tp):
-        attr = getattr(tp, attr_name)
-        if attr_name.startswith("test") and callable(attr):
-          setattr(tp, "%s_py2" % attr_name,
-                  _ReplacementMethod((2, 7), attr))
-          setattr(tp, "%s_py3" % attr_name,
-                  _ReplacementMethod((3, 6), attr))
-          delattr(tp, attr_name)
+        _ReplaceAttribute(tp, versions, attr_name)
   if is_main_module:
     unittest.main()

--- a/pytype/tests/test_utils.py
+++ b/pytype/tests/test_utils.py
@@ -443,4 +443,13 @@ def skipUnless37Available(f):
     else:
       _IS_37_AVAILABLE = True
   return unittest.skipUnless(_IS_37_AVAILABLE, "no python3.7")(f)
+
+
+def skipInVersion(python_version, reason):
+  """Skip the test in the (major, minor) version."""
+  def decorate(f):
+    # See test_base.main for how this attribute is used to skip the test.
+    f.__pytype_skip__ = (python_version, reason)
+    return f
+  return decorate
 # pylint: enable=invalid-name

--- a/pytype/tests/test_utils.py
+++ b/pytype/tests/test_utils.py
@@ -1,10 +1,13 @@
 """Utility class and function for tests."""
 
 import collections
+import subprocess
 
 from pytype import compat
 from pytype import state as frame_state
 from pytype.pyc import loadmarshal
+
+import unittest
 
 
 FakeCode = collections.namedtuple("FakeCode", "co_filename co_name")
@@ -418,3 +421,26 @@ class Py3Opcodes(object):
   BUILD_CONST_KEY_MAP = 156
   BUILD_STRING = 157
   BUILD_TUPLE_UNPACK_WITH_CALL = 158
+
+
+# We compute the availability of python3.7 with subprocess, which is slow, so
+# the result is cached.
+_IS_37_AVAILABLE = None
+
+
+# pylint: disable=invalid-name
+# Use camel-case to match the unittest.skip* methods.
+# TODO(rechen): Remove skipUnless37Available once python3.7 is available in all
+# of pytype's testing environments.
+def skipUnless37Available(f):
+  """Skip the test unless Python 3.7 is available."""
+  global _IS_37_AVAILABLE
+  if _IS_37_AVAILABLE is None:
+    try:
+      subprocess.call(["python3.7", "-V"])
+    except OSError:
+      _IS_37_AVAILABLE = False
+    else:
+      _IS_37_AVAILABLE = True
+  return unittest.skipUnless(_IS_37_AVAILABLE, "no python3.7")(f)
+# pylint: enable=invalid-name

--- a/pytype/tests/test_utils.py
+++ b/pytype/tests/test_utils.py
@@ -445,11 +445,11 @@ def skipUnless37Available(f):
   return unittest.skipUnless(_IS_37_AVAILABLE, "no python3.7")(f)
 
 
-def skipInVersion(python_version, reason):
-  """Skip the test in the (major, minor) version."""
+def skipIn37(reason):
+  """Skip the test in Python 3.7."""
   def decorate(f):
     # See test_base.main for how this attribute is used to skip the test.
-    f.__pytype_skip__ = (python_version, reason)
+    f.__pytype_skip__ = reason
     return f
   return decorate
 # pylint: enable=invalid-name

--- a/pytype/typing_overlay.py
+++ b/pytype/typing_overlay.py
@@ -515,7 +515,10 @@ class NamedTupleClassBuilder(abstract.PyTDClass):
 
   def call(self, node, _, args):
     posargs = args.posargs
-    namedargs = self.vm.convert.value_to_constant(args.namedargs, dict)
+    if isinstance(args.namedargs, dict):
+      namedargs = args.namedargs
+    else:
+      namedargs = self.vm.convert.value_to_constant(args.namedargs, dict)
     if namedargs and self.vm.python_version < (3, 6):
       errmsg = "Keyword syntax for NamedTuple is only supported in Python 3.6+"
       self.vm.errorlog.invalid_namedtuple_arg(self.vm.frames, err_msg=errmsg)


### PR DESCRIPTION
Fixes https://github.com/google/pytype/issues/208.
I tried to keep this change small by skipping tests rather than fixing them, but I did have to implement LOAD_METHOD and CALL_METHOD (or the majority of the 3.7 tests would've failed) and fix a crash involving function.Args.namedargs.