### PR TITLE
Travis CI: Use flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: xenial  # Python3.7 virtualenv is available only on Travis Xenial VMs.
-sudo: enabled
 
 git:
   submodules: true
@@ -37,8 +36,13 @@ addons:
     - python3.7-dev  # To build host extension modules under 3.7
 
 install:
-  - pip install importlab
-  - pip install pyyaml
-  - pip install six
+  - pip install flake8 importlab pyyaml six
+  
+before_script:
+  - EXCLUDE=./.*,pytype/test_data,pytype/tools
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count exclude=$EXCLUDE --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.
+  - flake8 . --count --exit-zero --ignore=E111,E114 --max-complexity=10 --max-line-length=80 --statistics
 
 script: python build_scripts/travis_script.py

--- a/pytype/compat.py
+++ b/pytype/compat.py
@@ -107,17 +107,14 @@ class IteratorType(object):
 NoneType = type(None)
 EllipsisType = type(Ellipsis)
 
-if sys.version_info[0] == 2:
-  # Because pylint doesn't respect version checks:
-  # pylint: disable=undefined-variable
-  BytesType = BytesPy3
+try:
   UnicodeType = unicode
   LongType = long
+  BytesType = BytesPy3
   OldStyleClassType = types.ClassType
-  # pylint: enable=undefined-variable
-elif sys.version_info[0] == 3:
-  BytesType = bytes
+except NameError:
   UnicodeType = UnicodePy2
   LongType = int
+  BytesType = bytes
   OldStyleClassType = OldStyleClassPy3
 # pylint: enable=invalid-name


### PR DESCRIPTION
Several of these are intentional and those lines can be marked with the linter directive # noqa

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree