### PR TITLE
Update the PyPI url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
     long_description=get_long_description(),
     maintainer='Google',
     maintainer_email='pytype@googlegroups.com',
-    url='https://github.com/google/pytype',
+    url='https://google.github.io/pytype',
     packages=[
         'pytype',
         'pytype/pyc',


### PR DESCRIPTION
Updates the URL that PyPI uses for the "Homepage" link on the left of the project page
(https://pypi.org/project/pytype/).