### PR TITLE
Re-export renamed typing module members.

### DIFF
--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -713,7 +713,9 @@ class _Parser(object):
           assert new_name == name
           new_name = t.name
         self._type_map[new_name] = t
-        if from_package != "typing" or self._ast_name == "protocols":
+        if (new_name != name or
+            from_package != "typing" or
+            self._ast_name == "protocols"):
           self._aliases[new_name] = pytd.Alias(new_name, t)
           self._module_path_map[name] = qualified_name
     else:

--- a/pytype/tests/py3/test_stdlib.py
+++ b/pytype/tests/py3/test_stdlib.py
@@ -324,5 +324,8 @@ class StdlibTestsFeatures(test_base.TargetPython3FeatureTest,
       f(Foo.foo)
     """)
 
+  def test_contextlib(self):
+    self.Check("from contextlib import AbstractContextManager")
+
 
 test_base.main(globals(), __name__ == "__main__")


### PR DESCRIPTION
This PR needs to be imported and re-exported.

contextlib.pyi does `from typing import ContextManager as AbstractContextManager`. Because we don't re-export names from typing, contextlib.AbstractContextManager wasn't accessible.

Fixes https://github.com/google/pytype/issues/256.

#pyfixit