### PR TITLE
Update the typeshed pin to match the internal version.

### DIFF
--- a/pytype/tests/py2/test_stdlib.py
+++ b/pytype/tests/py2/test_stdlib.py
@@ -6,6 +6,17 @@ from pytype.tests import test_base
 class StdlibTests(test_base.TargetPython27FeatureTest):
   """Tests for files in typeshed/stdlib."""
 
+  def testAST(self):
+    ty = self.Infer("""
+      import ast
+      def f():
+        return ast.parse("True")
+    """)
+    self.assertTypesMatchPytd(ty, """
+      ast = ...  # type: module
+      def f() -> _ast.Module
+    """)
+
   def testPosix(self):
     ty = self.Infer("""
       import posix

--- a/pytype/tests/py3/test_stdlib.py
+++ b/pytype/tests/py3/test_stdlib.py
@@ -83,6 +83,17 @@ class StdlibTestsFeatures(test_base.TargetPython3FeatureTest,
                           test_utils.TestCollectionsMixin):
   """Tests for files in typeshed/stdlib."""
 
+  def testAST(self):
+    ty = self.Infer("""
+      import ast
+      def f():
+        return ast.parse("True")
+    """)
+    self.assertTypesMatchPytd(ty, """
+      ast = ...  # type: module
+      def f() -> _ast.AST
+    """)
+
   def testCollectionsSmokeTest(self):
     # These classes are not fully implemented in typing.py.
     self.Check("""

--- a/pytype/tests/test_stdlib.py
+++ b/pytype/tests/test_stdlib.py
@@ -6,17 +6,6 @@ from pytype.tests import test_base
 class StdlibTests(test_base.TargetIndependentTest):
   """Tests for files in typeshed/stdlib."""
 
-  def testAST(self):
-    ty = self.Infer("""
-      import ast
-      def f():
-        return ast.parse("True")
-    """)
-    self.assertTypesMatchPytd(ty, """
-      ast = ...  # type: module
-      def f() -> _ast.Module
-    """)
-
   def testUrllib(self):
     ty = self.Infer("""
       import urllib


### PR DESCRIPTION
I've also copied over a test fix. From past experience, this shouldn't confuse copybara too much, although it'll probably generate an empty commit.