### PR TITLE
Travis CI: The 'sudo' tag is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: xenial  # Python3.7 virtualenv is available only on Travis Xenial VMs.
-sudo: enabled
 
 git:
   submodules: true


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"