### PR TITLE
made `python_verision` in pytype.cfg same as its runtime python version

### DIFF
--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -52,7 +52,8 @@ ITEMS = {
         '', '.', None,
         'Paths to source code directories, separated by %r.' % os.pathsep),
     'python_version': Item(
-        '', '3.6', None, 'Python version (major.minor) of the target code.'),
+        '', "{}.{}".format(*sys.version_info[:2]),
+        None, 'Python version (major.minor) of the target code.'),
 }
 
 

--- a/pytype/tools/analyze_project/config_test.py
+++ b/pytype/tools/analyze_project/config_test.py
@@ -7,6 +7,7 @@ from pytype import file_utils
 from pytype.tools.analyze_project import config
 from pytype.tools.analyze_project import parse_args
 import unittest
+import sys
 
 
 PYTYPE_CFG = """
@@ -141,6 +142,8 @@ class TestGenerateConfig(unittest.TestCase):
       expected_protocols = config._PYTYPE_SINGLE_ITEMS['protocols'].sample
       self.assertEqual(conf.pythonpath, expected_pythonpath)
       self.assertEqual(conf.protocols, expected_protocols)
+      self.assertEqual(conf.python_version, 
+                       "{}.{}".format(*sys.version_info[:2]))
 
   def test_read(self):
     with file_utils.Tempdir() as d:


### PR DESCRIPTION
from #270

Now the field "python_version" in pytype.cfg is same as its runtime Python version.

Before this PR, always the filed equals "3.6" regardless of what version of Python you use: 
```pytype.cfg
python_version = 3.6
```

After this PR, the fileld equals the version of Python which you use:
```pytype.cfg
python_version = (the version of Python which you use)
```

This is done by using `sys.version_info`.
