### PR TITLE
Change our development status from Stable to Production/Stable.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(
         'typed_ast',
     ],
     classifiers=[
-        'Development Status :: 5 - Stable',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',


### PR DESCRIPTION
PyPI doesn't seem to recognize Stable, and a classifer search shows
projects using Production/Stable.