### PR TITLE
Only require typed_ast in 3.3+.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,18 @@ def get_version():
   return about['__version__']
 
 
+def get_install_requires():
+  requires = [
+      'importlab (>=0.5)',
+      'ninja',
+      'pyyaml (>=3.11)',
+      'six',
+  ]
+  if sys.version_info >= (3, 3):
+    requires.append('typed_ast')
+  return requires
+
+
 copy_typeshed()
 if build_utils:
   e = build_utils.generate_files()
@@ -141,13 +153,7 @@ setup(
         ]
     },
     package_data={'pytype': get_builtin_files()},
-    install_requires=[
-        'importlab (>=0.5)',
-        'ninja',
-        'pyyaml (>=3.11)',
-        'six',
-        'typed_ast',
-    ],
+    install_requires=get_install_requires(),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
In lower versions, this requirement causes an installation failure:
https://travis-ci.org/google/python-fire/jobs/514951139.