### PR TITLE
Bump pytype's PyPI version number for a release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Version 2019.04.05
+* Improve Python 3 definitions in pytype's enum and typing stubs.
+
 Version 2019.04.02.1
 * Require typed_ast only in Python 3.3+.
 

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2019.04.02.1'
+__version__ = '2019.04.05'


### PR DESCRIPTION
PiperOrigin-RevId: 242158627