### PR TITLE
Run pylint over build_scripts/ and setup.py as well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,9 @@ addons:
 
 install:
   - pip install importlab
+  - pip install pylint
   - pip install pyyaml
   - pip install six
-  - pip install pylint
 
 script: 
   - python build_scripts/travis_script.py
-  - pylint pytype

--- a/build_scripts/py27.py
+++ b/build_scripts/py27.py
@@ -59,15 +59,15 @@ def build_backported_interpreter(clobber=False):
   print("Building Python-2.7 interpreter...\n")
   _prepare_directories(clobber)
   task_list = [
-    (_apply_patch, "Applying type annotations patch"),
-    ( _configure_build, "Configuring CPython build"),
-    ( _build, "Building patched CPython interpreter"),
-    ( _install, "Installing the CPython interpreter"),
-    ( _revert_patch, "Reverting type annotations patch"),
+      (_apply_patch, "Applying type annotations patch"),
+      (_configure_build, "Configuring CPython build"),
+      (_build, "Building patched CPython interpreter"),
+      (_install, "Installing the CPython interpreter"),
+      (_revert_patch, "Reverting type annotations patch"),
   ]
   for task, task_info in task_list:
     print("Python-2.7 build step: %s... " % task_info, end='')
-    returncode, stdout = task()
+    returncode, _ = task()
     if returncode != 0:
       print("FAILED\n" % task_info)
       return returncode

--- a/build_scripts/pyexe.py
+++ b/build_scripts/pyexe.py
@@ -51,14 +51,14 @@ def parse_args():
       "--main_module", "-m", required=True,
       help="The fully qualified name of the target main module of the exe.")
   parser.add_argument("--exe_path", "-x", required=True,
-                      help="Path to the Python executable.") 
+                      help="Path to the Python executable.")
   args = parser.parse_args()
   for env in args.env:
     if "=" not in env:
       sys.exit(
           "Environment variables should be specified in the form VAR=VALUE.")
   return args
-   
+
 
 def main():
   options = parse_args()
@@ -69,7 +69,7 @@ def main():
   env_adjustment = ""
   for env in options.env:
     var, value = env.split("=")
-    env_adjustment += "os.environ['%s'] = '%s'\n" % (var, value)    
+    env_adjustment += "os.environ['%s'] = '%s'\n" % (var, value)
 
   if "." in options.main_module:
     pkg, modname = options.main_module.rsplit(".", 1)

--- a/build_scripts/run_cc_test.py
+++ b/build_scripts/run_cc_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Script to run a C++ unit test binary.
 
-Usage: 
+Usage:
 
 $> python run_cc_test.py -t TARGET -b BINARY [-l LOGFILE]
 

--- a/build_scripts/run_tests.py
+++ b/build_scripts/run_tests.py
@@ -12,8 +12,6 @@ CMake files will be run.
 
 from __future__ import print_function
 import argparse
-import os
-import subprocess
 import sys
 
 import build_utils

--- a/build_scripts/travis_script.py
+++ b/build_scripts/travis_script.py
@@ -41,13 +41,15 @@ def _run_steps(steps):
 
 
 def main():
-  s1 = STEP(name="Build",
+  s1 = STEP(name="Lint",
+            command=["pylint", "build_scripts/", "pytype/", "setup.py"])
+  s2 = STEP(name="Build",
             command=["python", build_utils.build_script("build.py")])
-  s2 = STEP(name="Run Tests",
+  s3 = STEP(name="Run Tests",
             command=["python", build_utils.build_script("run_tests.py"), "-f"])
-  s3 = STEP(name="Type Check",
+  s4 = STEP(name="Type Check",
             command=[os.path.join("out", "bin", "pytype")])
-  _run_steps([s1, s2, s3])
+  _run_steps([s1, s2, s3, s4])
   print("\n*** All build steps completed successfully! ***\n")
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,4 +1,5 @@
 [MASTER]
+
 # Add <file or directory> to the black list. It should be a base name, not a
 # path. You may set this option multiple times.
 ignore=test_data
@@ -8,12 +9,68 @@ ignore=test_data
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
-disable=no-member,no-self-use,no-else-return,protected-access,attribute-defined-outside-init,invalid-name,missing-docstring,too-many-arguments,wrong-import-order,too-few-public-methods,too-many-public-methods,duplicate-code,arguments-differ,too-many-branches,blacklisted-name,unused-argument,bad-option-value,too-many-locals,abstract-method,inconsistent-return-statements,too-many-return-statements,too-many-instance-attributes,too-many-ancestors,import-error,misplaced-comparison-constant,global-statement,assigning-non-slot,slots-on-old-class,too-many-nested-blocks,unbalanced-tuple-unpacking,too-many-statements,redefined-argument-from-local,cyclic-import,no-value-for-parameter,deprecated-method,no-name-in-module,method-hidden,raising-format-tuple,multiple-statements,len-as-condition,useless-super-delegation,trailing-newlines,syntax-error,signature-differs,redefined-outer-name,parse-error,consider-using-ternary,consider-using-enumerate,consider-iterating-dictionary,unnecessary-pass,useless-object-inheritance,comparison-with-itself,consider-using-in,chained-comparison,useless-import-alias,comparison-with-callable,no-else-raise
-
-[REFACTORING]
-no-else-return=no
+disable=
+  abstract-method,
+  arguments-differ,
+  assigning-non-slot,
+  attribute-defined-outside-init,
+  bad-option-value,
+  blacklisted-name,
+  chained-comparison,
+  comparison-with-callable,
+  comparison-with-itself,
+  consider-iterating-dictionary,
+  consider-using-enumerate,
+  consider-using-in,
+  consider-using-ternary,
+  cyclic-import,
+  deprecated-method,
+  duplicate-code,
+  global-statement,
+  import-error,
+  inconsistent-return-statements,
+  invalid-name,
+  len-as-condition,
+  method-hidden,
+  misplaced-comparison-constant,
+  missing-docstring,
+  multiple-statements,
+  no-else-raise,
+  no-else-return,
+  no-member,
+  no-name-in-module,
+  no-self-use,
+  no-value-for-parameter,
+  parse-error,
+  protected-access,
+  raising-format-tuple,
+  redefined-argument-from-local,
+  redefined-outer-name,
+  relative-import,
+  signature-differs,
+  slots-on-old-class,
+  syntax-error,
+  too-few-public-methods,
+  too-many-ancestors,
+  too-many-arguments,
+  too-many-branches,
+  too-many-instance-attributes,
+  too-many-locals,
+  too-many-nested-blocks,
+  too-many-public-methods,
+  too-many-return-statements,
+  too-many-statements,
+  trailing-newlines,
+  unbalanced-tuple-unpacking,
+  unnecessary-pass,
+  unused-argument,
+  useless-import-alias,
+  useless-object-inheritance,
+  useless-super-delegation,
+  wrong-import-order,
 
 [REPORTS]
+
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html
 output-format=text
@@ -27,7 +84,7 @@ include-ids=no
 files-output=no
 
 # Tells whether to display a full report or only the messages
-reports=yes
+reports=no
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which
@@ -100,6 +157,8 @@ notes=FIXME,XXX
 
 # Maximum number of characters on a single line.
 max-line-length=80
+
+# Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=(^.{1,80}\s\s# pytype:\s)|(^\s*# http)
 
 # Maximum number of lines in a module

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ def get_version():
   # Load the package's __version__.py module as a dictionary.
   about = {}
   with open(os.path.join(here, 'pytype', '__version__.py')) as f:
-    exec (f.read(), about)  # pylint: disable=exec-used
+    exec(f.read(), about)  # pylint: disable=exec-used
   return about['__version__']
 
 


### PR DESCRIPTION
* Lints the rest of our source files not in pytype/.
* Edits those files to be free of lint errors, disables relative-import
  because it only fires in 2.7 and doesn't seem to be useful.
* Tweaks pylintrc to be a little easier to read and maintain.
* Moves the pylint step from .travis.yml to build_scripts/travis_script,
  alphabetizes installs in .travis.yml.