### PR TITLE
WIP FIX:PATH issues when running in windows #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Platform support:
 * Pytype is currently developed and tested on Linux, which is the main supported
   platform.
 * Installation on MacOSX requires OSX 10.7 or higher and Xcode v8 or higher.
-* Windows is currently not supported.
+* Windows, pytype requires Python 3.3+ to analyze a different Python version from the one it's running under, and also report an error in the code when the launcher isn't found.
 
 ## Installing
 
@@ -199,7 +199,6 @@ of its dependencies.
 
 ## Roadmap
 
-* Windows support
 
 ## License
 Apache 2.0

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Platform support:
 * Pytype is currently developed and tested on Linux, which is the main supported
   platform.
 * Installation on MacOSX requires OSX 10.7 or higher and Xcode v8 or higher.
-* Windows, pytype requires Python 3.3+ to analyze a different Python version from the one it's running under, and also report an error in the code when the launcher isn't found.
+* Windows requires Python 3.3 or higher
 
 ## Installing
 

--- a/pytype/pyc/pyc.py
+++ b/pytype/pyc/pyc.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 import tempfile
 import sys
-import logging
 from pytype import pytype_source_utils
 from pytype import utils
 from pytype.pyc import loadmarshal

--- a/pytype/pyc/pyc.py
+++ b/pytype/pyc/pyc.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import tempfile
 import sys
-
+import logging
 from pytype import pytype_source_utils
 from pytype import utils
 from pytype.pyc import loadmarshal
@@ -83,7 +83,10 @@ def compile_src_string_to_pyc_string(src, filename, python_version, python_exe,
     cmd = exe + ["-E", "-", fi.name, filename or fi.name, mode]
     compile_script_src = pytype_source_utils.load_pytype_file(COMPILE_SCRIPT)
 
-    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    try:
+      p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+      logging.error("CalledProcessError error: %s\n", str(e))
     bytecode, _ = p.communicate(compile_script_src)
     assert p.poll() == 0, "Child process failed"
   finally:

--- a/pytype/pyc/pyc.py
+++ b/pytype/pyc/pyc.py
@@ -71,8 +71,7 @@ def compile_src_string_to_pyc_string(src, filename, python_version, python_exe,
     # we spawn an external process.
     if python_exe:
       if sys.platform == 'win32':
-        exe = ["py"]
-        exe.append("-" + ".".join(map(str, python_version)))
+        exe = ["py", "-" + ".".join(map(str, python_version))]
       else:
         # Allow python_exe to contain parameters (E.g. "-T")
         exe = python_exe.split()
@@ -85,8 +84,8 @@ def compile_src_string_to_pyc_string(src, filename, python_version, python_exe,
 
     try:
       p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-    except subprocess.CalledProcessError as e:
-      logging.error("CalledProcessError error: %s\n", str(e))
+    except IOError:
+      return None
     bytecode, _ = p.communicate(compile_script_src)
     assert p.poll() == 0, "Child process failed"
   finally:

--- a/pytype/pyc/pyc.py
+++ b/pytype/pyc/pyc.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import tempfile
+import sys
 
 from pytype import pytype_source_utils
 from pytype import utils
@@ -76,6 +77,8 @@ def compile_src_string_to_pyc_string(src, filename, python_version, python_exe,
     # We pass -E to ignore the environment so that PYTHONPATH and sitecustomize
     # on some people's systems don't mess with the interpreter.
     cmd = exe + ["-E", "-", fi.name, filename or fi.name, mode]
+    if sys.platform == 'win32':
+      cmd = ["python", "-E", "-", fi.name, filename or fi.name, mode]
 
     compile_script_src = pytype_source_utils.load_pytype_file(COMPILE_SCRIPT)
 

--- a/pytype/pyc/pyc.py
+++ b/pytype/pyc/pyc.py
@@ -70,16 +70,17 @@ def compile_src_string_to_pyc_string(src, filename, python_version, python_exe,
     # In order to be able to compile pyc files for both Python 2 and Python 3,
     # we spawn an external process.
     if python_exe:
-      # Allow python_exe to contain parameters (E.g. "-T")
-      exe = python_exe.split()
+      if sys.platform == 'win32':
+        exe = ["py"]
+        exe.append("-" + ".".join(map(str, python_version)))
+      else:
+        # Allow python_exe to contain parameters (E.g. "-T")
+        exe = python_exe.split()
     else:
       exe = ["python" + ".".join(map(str, python_version))]
     # We pass -E to ignore the environment so that PYTHONPATH and sitecustomize
     # on some people's systems don't mess with the interpreter.
     cmd = exe + ["-E", "-", fi.name, filename or fi.name, mode]
-    if sys.platform == 'win32':
-      cmd = ["python", "-E", "-", fi.name, filename or fi.name, mode]
-
     compile_script_src = pytype_source_utils.load_pytype_file(COMPILE_SCRIPT)
 
     p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)

--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -433,7 +433,7 @@ class _Parser(object):
 
     try:
       if sys.platform == 'win32':
-        if type(src) is type(bytes):
+        if isinstance(src, bytes):
           src = src.decode('utf-8').replace('\r', '')
           src = src.encode('utf-8')
       defs = parser_ext.parse(self, src)

--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -2,6 +2,7 @@
 
 import collections
 import hashlib
+import sys
 
 from pytype import file_utils
 from pytype import module_utils
@@ -431,6 +432,10 @@ class _Parser(object):
     self._parent_name = module_utils.get_package_name(self._package_name, False)
 
     try:
+      if sys.platform == 'win32':
+        if type(src) is type(bytes):
+          src = src.decode('utf-8').replace('\r', '')
+          src = src.encode('utf-8')
       defs = parser_ext.parse(self, src)
       ast = self._build_type_decl_unit(defs)
     except ParseError as e:

--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import logging
 import os
 import subprocess
+import sys
 
 from pytype import file_utils
 from pytype import module_utils
@@ -273,13 +274,20 @@ class PytypeRunner(object):
                           _module_to_output_path(module) + '.pyi' + suffix)
     logging.info('%s %s\n  imports: %s\n  deps: %s\n  output: %s',
                  action, module.name, imports, deps, output)
+    input_path = module.full_path
+
+    if sys.platform == 'win32':
+      output = output.replace('C:', 'C$:')
+      input_path = module.full_path.replace('C:', 'C$:')
+      imports = imports.replace('C:', 'C$:')
+
     with open(self.ninja_file, 'a') as f:
       f.write('build {output}: {action} {input}{deps}\n'
               '  imports = {imports}\n'
               '  module = {module}\n'.format(
                   output=output,
                   action=action,
-                  input=module.full_path,
+                  input=input_path,
                   deps=' | ' + ' '.join(deps) if deps else '',
                   imports=imports,
                   module=module.name))

--- a/pytype/utils.py
+++ b/pytype/utils.py
@@ -156,14 +156,11 @@ def get_python_exe_version(python_exe):
   Returns:
     Version as (major, minor) tuple.
   """
+  if sys.platform == 'win32':
+    python_exe = "py -" + python_exe.replace('python', '')
   try:
-    if sys.platform == 'win32':
-      python_exe_version = subprocess.check_output(
-          "python" + " -V", shell=True, stderr=subprocess.STDOUT).decode()
-    else:
-      python_exe_version = subprocess.check_output(
-          python_exe + " -V", shell=True, stderr=subprocess.STDOUT).decode()
-
+    python_exe_version = subprocess.check_output(
+      python_exe + " -V", shell=True, stderr=subprocess.STDOUT).decode()
   except subprocess.CalledProcessError:
     return None
 

--- a/pytype/utils.py
+++ b/pytype/utils.py
@@ -8,6 +8,7 @@ import subprocess
 import threading
 import types
 import weakref
+import sys
 
 from pytype import pytype_source_utils
 
@@ -156,8 +157,13 @@ def get_python_exe_version(python_exe):
     Version as (major, minor) tuple.
   """
   try:
-    python_exe_version = subprocess.check_output(
-        python_exe + " -V", shell=True, stderr=subprocess.STDOUT).decode()
+    if sys.platform == 'win32':
+      python_exe_version = subprocess.check_output(
+          "python" + " -V", shell=True, stderr=subprocess.STDOUT).decode()
+    else:
+      python_exe_version = subprocess.check_output(
+          python_exe + " -V", shell=True, stderr=subprocess.STDOUT).decode()
+
   except subprocess.CalledProcessError:
     return None
 

--- a/pytype/utils.py
+++ b/pytype/utils.py
@@ -160,7 +160,7 @@ def get_python_exe_version(python_exe):
     python_exe = "py -" + python_exe.replace('python', '')
   try:
     python_exe_version = subprocess.check_output(
-      python_exe + " -V", shell=True, stderr=subprocess.STDOUT).decode()
+        python_exe + " -V", shell=True, stderr=subprocess.STDOUT).decode()
   except subprocess.CalledProcessError:
     return None
 


### PR DESCRIPTION
Hi
I have experimentally implemented a Windows support.
OS: Windows 8
Python version: 3.7

1. change python_exe to "python"
(pyc/pyc.py, pytype/utils.py)

2. replace `r` for ``
(pyi/parser.py)

3. change C: to C$:
(pytype_runner.py)

This PR is still work in progress. I have  I think there are some discussion points as a follow:
・`if sys.platform == win32` are frequently.
Should I write proper settings  for each platform in set.py?
