### PR TITLE
Fix a bug where pytype would fail to resolve an unused import.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Version 2019.05.08
+* Fix a bug in pyi lookup of re-exported imports.
+
 Version 2019.05.06
 * Update typeshed pin to commit 4e572ae from April 23.
 * Support collections.namedtuple in pyi files.

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2019.05.06'
+__version__ = '2019.05.08'

--- a/pytype/pytd/serialize_ast.py
+++ b/pytype/pytd/serialize_ast.py
@@ -149,8 +149,8 @@ def StoreAst(ast, filename=None):
   # Collect dependencies
   deps = visitors.CollectDependencies()
   ast.Visit(deps)
-  dependencies = deps.modules
-  late_dependencies = deps.late_modules
+  dependencies = deps.dependencies
+  late_dependencies = deps.late_dependencies
 
   # Clean external references
   ast.Visit(visitors.ClearClassPointers())
@@ -158,10 +158,10 @@ def StoreAst(ast, filename=None):
   ast.Visit(indexer)
   ast = ast.Visit(visitors.CanonicalOrderingVisitor())
   return pytd_utils.SavePickle(SerializableAst(
-      ast, list(sorted(dependencies)),
-      list(sorted(late_dependencies)),
-      list(sorted(indexer.class_type_nodes)),
-      list(sorted(indexer.function_type_nodes))), filename)
+      ast, sorted(dependencies.items()),
+      sorted(late_dependencies.items()),
+      sorted(indexer.class_type_nodes),
+      sorted(indexer.function_type_nodes)), filename)
 
 
 def EnsureAstName(ast, module_name, fix=False):

--- a/pytype/pytd/serialize_ast_test.py
+++ b/pytype/pytd/serialize_ast_test.py
@@ -6,6 +6,7 @@ from pytype import load_pytd
 from pytype.pytd import pytd_utils
 from pytype.pytd import serialize_ast
 from pytype.pytd import visitors
+import six
 
 import unittest
 
@@ -162,8 +163,8 @@ class SerializeAstTest(unittest.TestCase):
       with open(pickled_ast_filename, "rb") as fi:
         serialized_ast = pickle.load(fi)
       self.assertTrue(serialized_ast.ast)
-      self.assertEqual(serialized_ast.dependencies,
-                       ["__builtin__", "foo.bar.module1", "module2"])
+      six.assertCountEqual(self, dict(serialized_ast.dependencies),
+                           ["__builtin__", "foo.bar.module1", "module2"])
 
   def testUnrestorableChild(self):
     # Assume .cls in a ClassType X in module1 was referencing something for

--- a/pytype/pytd/typeshed.py
+++ b/pytype/pytd/typeshed.py
@@ -224,7 +224,8 @@ def parse_type_definition(pyi_subdir, module, python_version):
     python_version: sys.version_info[:2]
 
   Returns:
-    The AST of the module; None if the module doesn't have a definition.
+    None if the module doesn't have a definition.
+    Else a tuple of the filename and the AST of the module.
   """
   assert python_version
   typeshed = _get_typeshed()
@@ -234,5 +235,5 @@ def parse_type_definition(pyi_subdir, module, python_version):
   except IOError:
     return None
 
-  return parser.parse_string(src, filename=filename, name=module,
-                             python_version=python_version)
+  return filename, parser.parse_string(src, filename=filename, name=module,
+                                       python_version=python_version)

--- a/pytype/pytd/typeshed_test.py
+++ b/pytype/pytd/typeshed_test.py
@@ -28,7 +28,8 @@ class TestTypeshedLoading(parser_test_base.ParserTest):
     self.assertIn(b"LogRecord", data)
 
   def test_parse_type_definition(self):
-    ast = typeshed.parse_type_definition("stdlib", "_random", (2, 7))
+    filename, ast = typeshed.parse_type_definition("stdlib", "_random", (2, 7))
+    self.assertEqual(os.path.basename(filename), "_random.pyi")
     self.assertIn("_random.Random", [cls.name for cls in ast.classes])
 
   def test_get_typeshed_missing(self):

--- a/pytype/pytd/visitors_test.py
+++ b/pytype/pytd/visitors_test.py
@@ -476,7 +476,7 @@ class TestVisitors(parser_test_base.ParserTest):
     """)
     deps = visitors.CollectDependencies()
     self.Parse(src).Visit(deps)
-    self.assertSetEqual({"baz", "bar", "foo.bar"}, deps.modules)
+    six.assertCountEqual(self, {"baz", "bar", "foo.bar"}, deps.dependencies)
 
   def testCollectDependenciesOnFunctionType(self):
     other = self.Parse("""
@@ -485,7 +485,7 @@ class TestVisitors(parser_test_base.ParserTest):
     ast = pytd.FunctionType("foo.bar", other.Lookup("f"))
     deps = visitors.CollectDependencies()
     ast.Visit(deps)
-    self.assertSetEqual({"foo"}, deps.modules)
+    six.assertCountEqual(self, {"foo"}, deps.dependencies)
 
   def testExpand(self):
     src = textwrap.dedent("""

--- a/pytype/tests/test_pickle.py
+++ b/pytype/tests/test_pickle.py
@@ -24,13 +24,13 @@ class PickleTest(test_base.TargetIndependentTest):
   def _verifyDeps(self, module, immediate_deps, late_deps):
     if isinstance(module, bytes):
       data = cPickle.loads(module)
-      six.assertCountEqual(self, data.dependencies, immediate_deps)
-      six.assertCountEqual(self, data.late_dependencies, late_deps)
+      six.assertCountEqual(self, dict(data.dependencies), immediate_deps)
+      six.assertCountEqual(self, dict(data.late_dependencies), late_deps)
     else:
       c = visitors.CollectDependencies()
       module.Visit(c)
-      six.assertCountEqual(self, c.modules, immediate_deps)
-      six.assertCountEqual(self, c.late_modules, late_deps)
+      six.assertCountEqual(self, c.dependencies, immediate_deps)
+      six.assertCountEqual(self, c.late_dependencies, late_deps)
 
   def testType(self):
     pickled = self.Infer("""

--- a/pytype/tools/xref/indexer.py
+++ b/pytype/tools/xref/indexer.py
@@ -1096,7 +1096,8 @@ class Indexer(object):
         else:
           sig = "module." + defn.name
         if path.startswith("pytd:"):
-          return self.kythe.builtin_vname(sig, path)
+          return self.kythe.builtin_vname(
+              sig, "pytd:" + self.resolved_modules[remote].module_name)
         else:
           return self.kythe.vname(sig, path)
       else:


### PR DESCRIPTION
This is a problem when a pyi files does `from X import Y as Y` with
the intent to re-export Y. pytype would see Alias(Y, X.Y) and assume
that X was a module and Y a module attribute. Instead, we need to
detect when X is a package and attempt to load a pyi for X.Y.

When this is LGTM'd, I'll update __version__ and CHANGELOG with
the current date before submitting, so that I can do a PyPI release
and unblacklist the affected third_party typeshed files.

Makes progress toward https://github.com/google/pytype/issues/171.

PiperOrigin-RevId: 247335339