### PR TITLE
Update typeshed to 50d98acc766e9425cb099c17b711f1bccb697584.

### DIFF
--- a/pytype/mixin.py
+++ b/pytype/mixin.py
@@ -259,7 +259,8 @@ class Class(object):
 
   @property
   def is_test_class(self):
-    return any(base.full_name == "unittest.TestCase" for base in self.mro)
+    return any(base.full_name in ("unittest.TestCase", "unittest.case.TestCase")
+               for base in self.mro)
 
   @property
   def is_protocol(self):

--- a/pytype/tests/py2/test_classes.py
+++ b/pytype/tests/py2/test_classes.py
@@ -23,5 +23,42 @@ class ClassesTest(test_base.TargetPython27FeatureTest):
       x = ...  # type: Any
     """)
 
+  def testInitTestClassInSetup(self):
+    ty = self.Infer("""\
+      import unittest
+      class A(unittest.TestCase):
+        def setUp(self):
+          self.x = 10
+        def fooTest(self):
+          return self.x
+    """)
+    self.assertTypesMatchPytd(ty, """
+      import unittest
+      unittest = ...  # type: module
+      class A(unittest.TestCase):
+          x = ...  # type: int
+          def fooTest(self) -> int: ...
+    """)
+
+  def testInitInheritedTestClassInSetup(self):
+    ty = self.Infer("""\
+      import unittest
+      class A(unittest.TestCase):
+        def setUp(self):
+          self.x = 10
+      class B(A):
+        def fooTest(self):
+          return self.x
+    """)
+    self.assertTypesMatchPytd(ty, """
+      import unittest
+      unittest = ...  # type: module
+      class A(unittest.TestCase):
+          x = ...  # type: int
+      class B(A):
+          x = ...  # type: int
+          def fooTest(self) -> int: ...
+    """)
+
 
 test_base.main(globals(), __name__ == "__main__")

--- a/pytype/tests/py3/test_classes.py
+++ b/pytype/tests/py3/test_classes.py
@@ -194,27 +194,6 @@ class ClassesTest(test_base.TargetPython3BasicTest):
         bar: int
     """)
 
-  def testInitTestClassInInitAndSetup(self):
-    ty = self.Infer("""\
-      import unittest
-      class A(unittest.TestCase):
-        def __init__(self, foo: str):
-          self.foo = foo
-        def setUp(self):
-          self.x = 10
-        def fooTest(self):
-          return self.x
-    """)
-    self.assertTypesMatchPytd(ty, """
-      import unittest
-      unittest = ...  # type: module
-      class A(unittest.TestCase):
-          x = ...  # type: int
-          foo = ...  # type: str
-          def __init__(self, foo: str) -> NoneType
-          def fooTest(self) -> int: ...
-    """)
-
 
 class ClassesTestPython3Feature(test_base.TargetPython3FeatureTest):
   """Tests for classes."""
@@ -285,6 +264,64 @@ class ClassesTestPython3Feature(test_base.TargetPython3FeatureTest):
       def f(x: Foo):
         pass
       f(Bar())
+    """)
+
+  def testInitTestClassInSetup(self):
+    ty = self.Infer("""\
+      import unittest
+      class A(unittest.TestCase):
+        def setUp(self):
+          self.x = 10
+        def fooTest(self):
+          return self.x
+    """)
+    self.assertTypesMatchPytd(ty, """
+      import unittest
+      unittest = ...  # type: module
+      class A(unittest.case.TestCase):
+          x = ...  # type: int
+          def fooTest(self) -> int: ...
+    """)
+
+  def testInitInheritedTestClassInSetup(self):
+    ty = self.Infer("""\
+      import unittest
+      class A(unittest.TestCase):
+        def setUp(self):
+          self.x = 10
+      class B(A):
+        def fooTest(self):
+          return self.x
+    """)
+    self.assertTypesMatchPytd(ty, """
+      import unittest
+      unittest = ...  # type: module
+      class A(unittest.case.TestCase):
+          x = ...  # type: int
+      class B(A):
+          x = ...  # type: int
+          def fooTest(self) -> int: ...
+    """)
+
+  def testInitTestClassInInitAndSetup(self):
+    ty = self.Infer("""\
+      import unittest
+      class A(unittest.TestCase):
+        def __init__(self, foo: str):
+          self.foo = foo
+        def setUp(self):
+          self.x = 10
+        def fooTest(self):
+          return self.x
+    """)
+    self.assertTypesMatchPytd(ty, """
+      import unittest
+      unittest = ...  # type: module
+      class A(unittest.case.TestCase):
+          x = ...  # type: int
+          foo = ...  # type: str
+          def __init__(self, foo: str) -> NoneType
+          def fooTest(self) -> int: ...
     """)
 
 

--- a/pytype/tests/test_classes.py
+++ b/pytype/tests/test_classes.py
@@ -1367,43 +1367,6 @@ class ClassesTest(test_base.TargetIndependentTest):
         x = ...  # type: int
     """)
 
-  def testInitTestClassInSetup(self):
-    ty = self.Infer("""\
-      import unittest
-      class A(unittest.TestCase):
-        def setUp(self):
-          self.x = 10
-        def fooTest(self):
-          return self.x
-    """)
-    self.assertTypesMatchPytd(ty, """
-      import unittest
-      unittest = ...  # type: module
-      class A(unittest.TestCase):
-          x = ...  # type: int
-          def fooTest(self) -> int: ...
-    """)
-
-  def testInitInheritedTestClassInSetup(self):
-    ty = self.Infer("""\
-      import unittest
-      class A(unittest.TestCase):
-        def setUp(self):
-          self.x = 10
-      class B(A):
-        def fooTest(self):
-          return self.x
-    """)
-    self.assertTypesMatchPytd(ty, """
-      import unittest
-      unittest = ...  # type: module
-      class A(unittest.TestCase):
-          x = ...  # type: int
-      class B(A):
-          x = ...  # type: int
-          def fooTest(self) -> int: ...
-    """)
-
   def testPyiNestedClass(self):
     # Test that pytype can look up a pyi nested class in a py file and reconsume
     # the inferred pyi.


### PR DESCRIPTION
Also updates `pytype/mixin.py` and some test cases to reflect that in py3,
`unittest.TestCase` is in `unittest/case.pyi` rather than `unittest/__init__.pyi`.

Fixes https://github.com/google/pytype/issues/150,
makes a lot of progress toward https://github.com/google/pytype/issues/171.