### PR TITLE
Allow trailing commas in lists in type stubs.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Version 2019.07.30
+* Allow trailing commas in lists in type stubs.
+
 Version 2019.07.26
 * Update typeshed pin to commit 40215d1 from July 18.
 * Improve support for subprocess.Popen in Python 3.

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2019.07.26'
+__version__ = '2019.07.30'

--- a/pytype/pyi/parser.yy
+++ b/pytype/pyi/parser.yy
@@ -591,7 +591,7 @@ type
       $$ = ctx->Call(kNewType, "(N)", $1);
       CHECK($$, @$);
     }
-  | dotted_name '[' type_parameters ']' {
+  | dotted_name '[' type_parameters maybe_comma ']' {
       $$ = ctx->Call(kNewType, "(NN)", $1, $3);
       CHECK($$, @$);
     }
@@ -650,7 +650,7 @@ coll_named_tuple_field
   : NAME { $$ = Py_BuildValue("(NN)", $1, ctx->Value(kAnything)); }
 
 maybe_type_list
-  : type_list { $$ = $1; }
+  : type_list maybe_comma { $$ = $1; }
   | /* EMPTY */ { $$ = PyList_New(0); }
   ;
 

--- a/pytype/pyi/parser_test.py
+++ b/pytype/pyi/parser_test.py
@@ -453,6 +453,23 @@ class ParserTest(_ParserTestBase):
     self.assertEqual("foo.bar.X.Baz", ast.Lookup("foo.y").type.name)
     self.assertEqual("bar.X.Baz", ast.Lookup("foo.z").type.name)
 
+  def test_trailing_list_comma(self):
+    self.check("""\
+      from typing import Any, Callable
+
+      x: Callable[
+        [
+          int,
+          int,
+        ],
+        Any,
+      ]
+    """, """\
+      from typing import Any, Callable
+
+      x: Callable[[int, int], Any]
+    """)
+
 
 class HomogeneousTypeTest(_ParserTestBase):
 
@@ -700,10 +717,7 @@ class NamedTupleTest(_ParserTestBase):
     """)
 
   def test_collections_namedtuple(self):
-    self.check("""
-      from collections import namedtuple
-      X = namedtuple("X", ["y"])
-    """, """\
+    expected = """\
       from typing import Any, Tuple, Type, TypeVar
 
       from collections import namedtuple
@@ -723,7 +737,15 @@ class NamedTupleTest(_ParserTestBase):
           _replace: Any
           def __new__(cls: Type[`_Tnamedtuple-X-0`], y) -> `_Tnamedtuple-X-0`: ...
           def __init__(self, *args, **kwargs) -> None: ...
-    """)
+    """
+    self.check("""
+      from collections import namedtuple
+      X = namedtuple("X", ["y"])
+    """, expected)
+    self.check("""
+      from collections import namedtuple
+      X = namedtuple("X", ["y",])
+    """, expected)
 
 
 class FunctionTest(_ParserTestBase):


### PR DESCRIPTION
Addresses failing pytype test in https://github.com/python/typeshed/pull/3149.

I'm planning to do a mini external release today for this fix, since the
internal release includes everything up to it, and the parser change has a very
low likelihood of breaking anything.

PiperOrigin-RevId: 260765164