### PR TITLE
Don't lint or test xref in Python 2.

### DIFF
--- a/build_scripts/run_tests.py
+++ b/build_scripts/run_tests.py
@@ -38,7 +38,12 @@ def parse_args():
 
 def main():
   opts = parse_args()
-  targets = opts.targets or ["test_all"]
+  if opts.targets:
+    targets = opts.targets
+  elif sys.version_info.major == 2:
+    targets = ["test_all_py2"]
+  else:
+    targets = ["test_all"]
   if not build_utils.run_cmake(log_output=True, debug_build=opts.debug):
     sys.exit(1)
   fail_collector = build_utils.FailCollector()

--- a/build_scripts/travis_script.py
+++ b/build_scripts/travis_script.py
@@ -40,9 +40,16 @@ def _run_steps(steps):
     _end_step(s)
 
 
+def _pylint_command():
+  cmd = ["pylint", "build_scripts/", "pytype/", "setup.py"]
+  if sys.version_info.major == 2:
+    cmd.append("--ignore=xref")
+  return cmd
+
+
 def main():
   s1 = STEP(name="Lint",
-            command=["pylint", "build_scripts/", "pytype/", "setup.py"])
+            command=_pylint_command())
   s2 = STEP(name="Build",
             command=["python", build_utils.build_script("build.py")])
   s3 = STEP(name="Run Tests",

--- a/cmake/modules/PyTypeUtils.cmake
+++ b/cmake/modules/PyTypeUtils.cmake
@@ -42,6 +42,11 @@ add_custom_target(
   ${ALL_TESTS_TARGET}
 )
 
+set(ALL_TESTS_TARGET_PY2 "test_all_py2")
+add_custom_target(
+  ${ALL_TESTS_TARGET_PY2}
+)
+
 string(COMPARE EQUAL "${CMAKE_BUILD_TYPE}" "Debug" is_debug_build)
 if(is_debug_build)
   add_definitions(-DPYTYPE_ENABLE_CPP_LOGGING)
@@ -349,6 +354,7 @@ function(cc_test)
   )
 
   add_dependencies(${ALL_TESTS_TARGET} ${fq_target_name})
+  add_dependencies(${ALL_TESTS_TARGET_PY2} ${fq_target_name})
 endfunction(cc_test)
 
 # Function implementing a rule 'py_extension' to compile a set of CC and headers
@@ -515,7 +521,7 @@ function(py_test)
     ${ARGN}
   )
   if(NOT PY_TEST_NAME)
-    message(FATAL_ERROR "'py_library' rule requires a NAME argument.")
+    message(FATAL_ERROR "'py_test' rule requires a NAME argument.")
   endif()
 
   _gen_fq_target_name(${PY_TEST_NAME} fq_target_name)
@@ -554,6 +560,9 @@ function(py_test)
   endif()
 
   add_dependencies(${ALL_TESTS_TARGET} ${fq_target_name})
+  if(NOT ${CMAKE_CURRENT_BINARY_DIR} MATCHES "xref$")
+    add_dependencies(${ALL_TESTS_TARGET_PY2} ${fq_target_name})
+  endif()
 endfunction(py_test)
 
 function(filegroup)


### PR DESCRIPTION
I poked around at this a bit more and discovered that excluding tests in Python 2 isn't as messy as I was afraid it would be, so we should just go ahead and do it so we can stop worrying about accidentally using py3-only features in xref. I also found what was likely a copy/paste error in the cmake file ('py_library' instead of 'py_test'), so I fixed that, too.