### PR TITLE
Add a verbose mode to print failing test logs to stderr.

### DIFF
--- a/build_scripts/build_utils.py
+++ b/build_scripts/build_utils.py
@@ -187,8 +187,9 @@ def run_cmake(force_clean=False, log_output=False, debug_build=False):
 class FailCollector(object):
   """A class to collect failures."""
 
-  def __init__(self):
+  def __init__(self, verbose):
     self._failures = []
+    self._verbose = verbose
 
   def add_failure(self, mod_name, log_file):
     self._failures.append((mod_name, log_file))
@@ -201,7 +202,11 @@ class FailCollector(object):
     for mod_name, log_file in self._failures:
       msg = "** %s" % mod_name
       if log_file:
-        msg += " - %s" % log_file
+        if self._verbose:
+          with open(log_file.strip(), 'r') as f:
+            msg += '\n' + f.read()
+        else:
+          msg += " - %s" % log_file
       print(msg)
 
 

--- a/build_scripts/build_utils.py
+++ b/build_scripts/build_utils.py
@@ -202,12 +202,11 @@ class FailCollector(object):
     for mod_name, log_file in self._failures:
       msg = "** %s" % mod_name
       if log_file:
-        if self._verbose:
-          with open(log_file.strip(), 'r') as f:
-            msg += '\n' + f.read()
-        else:
-          msg += " - %s" % log_file
+        msg += " - %s" % log_file
       print(msg)
+      if log_file and self._verbose:
+        with open(log_file.strip(), 'r') as f:
+          print(f.read(), file=sys.stderr)
 
 
 def run_ninja(targets, fail_collector=None, fail_fast=False):

--- a/build_scripts/run_tests.py
+++ b/build_scripts/run_tests.py
@@ -26,7 +26,7 @@ def parse_args():
   parser.add_argument("--debug", "-d", action="store_true", default=False,
                       help="Build targets in the debug mode.")
   parser.add_argument("--verbose", "-v", action="store_true", default=False,
-                      help="Print failing test logs to stdout.")
+                      help="Print failing test logs to stderr.")
   args = parser.parse_args()
   for target in args.targets:
     if "." in target:

--- a/build_scripts/run_tests.py
+++ b/build_scripts/run_tests.py
@@ -25,6 +25,8 @@ def parse_args():
                       help="Fail as soon as one build target fails.")
   parser.add_argument("--debug", "-d", action="store_true", default=False,
                       help="Build targets in the debug mode.")
+  parser.add_argument("--verbose", "-v", action="store_true", default=False,
+                      help="Print failing test logs to stdout.")
   args = parser.parse_args()
   for target in args.targets:
     if "." in target:
@@ -46,7 +48,7 @@ def main():
     targets = ["test_all"]
   if not build_utils.run_cmake(log_output=True, debug_build=opts.debug):
     sys.exit(1)
-  fail_collector = build_utils.FailCollector()
+  fail_collector = build_utils.FailCollector(opts.verbose)
   print("Running tests (build steps will be executed as required) ...\n")
   if not build_utils.run_ninja(targets, fail_collector, opts.fail_fast):
     fail_collector.print_report()

--- a/build_scripts/travis_script.py
+++ b/build_scripts/travis_script.py
@@ -53,7 +53,8 @@ def main():
   s2 = STEP(name="Build",
             command=["python", build_utils.build_script("build.py")])
   s3 = STEP(name="Run Tests",
-            command=["python", build_utils.build_script("run_tests.py"), "-f"])
+            command=[
+                "python", build_utils.build_script("run_tests.py"), "-f", "-v"])
   s4 = STEP(name="Type Check",
             command=[os.path.join("out", "bin", "pytype")])
   _run_steps([s1, s2, s3, s4])


### PR DESCRIPTION
Currently, when a test fails on Travis, we get no information except the
test name and a path to a log file we can't access. Instead, we should
print the log file to stderr.