### PR TITLE
Update pytype __version__ and CHANGELOG for a PyPI release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
-Version (upcoming)
+Version 2019.08.29
 * Improve the usability of the pytype.io module.
 * Add basic callgraph generation to pytype.tools.xref.
+* Update typeshed pin to commit fab2ee0 from August 16.
+* Add an experimental --precise-return mode.
 
 Version 2019.08.09
 * Partially support typing[_extensions].Literal in pyi files.

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2019.08.09'
+__version__ = '2019.08.29'


### PR DESCRIPTION
http://dashboards/pytype_status shows only a handful of failures, none of which
look like pytype bugs.

PiperOrigin-RevId: 266233511