### PR TITLE
Temporary fix for sorting errors

### DIFF
--- a/pytype/errors.py
+++ b/pytype/errors.py
@@ -436,7 +436,7 @@ class ErrorLogBase(object):
     return sum(unique_errors.values(), [])
 
   def _sorted_errors(self):
-    return sorted(self._errors, key=lambda x: (x.filename, x.lineno))
+    return sorted(self._errors, key=lambda x: (x.filename or '', x.lineno))
 
   def print_to_stderr(self):
     self.print_to_file(sys.stderr)

--- a/pytype/errors_test.py
+++ b/pytype/errors_test.py
@@ -207,6 +207,21 @@ class ErrorLogBaseTest(unittest.TestCase):
     self.assertIsNone(unique_errors[0]._traceback)
 
   @errors._error_name(_TEST_ERROR)
+  def test_error_without_stack(self):
+    errorlog = errors.ErrorLog()
+    stack = test_utils.fake_stack(1)
+    errorlog.error(stack, "error_with_stack")
+    errorlog.error([], "error_without_stack")
+    unique_errors = errorlog.unique_sorted_errors()
+    unique_errors = [(error.message, error.filename, error.lineno)
+                     for error in unique_errors
+                    ]
+    self.assertEqual(
+        [('error_without_stack', None, 0), ('error_with_stack', 'foo.py', 0)],
+        unique_errors,
+    )
+
+  @errors._error_name(_TEST_ERROR)
   def test_duplicate_error_shorter_traceback(self):
     errorlog = errors.ErrorLog()
     stack = test_utils.fake_stack(3)


### PR DESCRIPTION
An alternative way to avoid exception during sorting errors.
This can be a temporary fix if you want to remove nullability of fileno field or disallow creating errors without lineno in the future.