### PR TITLE
Temporarily pin to an older version of pylint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ addons:
 
 install:
   - pip install importlab
-  - pip install pylint
+  - pip install astroid==2.2.5
+  - pip install pylint==2.3.1
   - pip install pyyaml
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then pip install typed_ast; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ addons:
 
 install:
   - pip install importlab
-  - pip install astroid<2.3.0
-  - pip install pylint<2.4.0
+  - pip install 'astroid<=2.2.5'
+  - pip install 'pylint<=2.3.1'
   - pip install pyyaml
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then pip install typed_ast; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ addons:
 
 install:
   - pip install importlab
-  - pip install astroid==2.2.5
-  - pip install pylint==2.3.1
+  - pip install astroid<=2.2.5
+  - pip install pylint<=2.3.1
   - pip install pyyaml
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then pip install typed_ast; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ addons:
 
 install:
   - pip install importlab
-  - pip install astroid<=2.2.5
-  - pip install pylint<=2.3.1
+  - pip install astroid<2.3.0
+  - pip install pylint<2.4.0
   - pip install pyyaml
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then pip install typed_ast; fi


### PR DESCRIPTION
See https://github.com/google/pytype/issues/423.