### PR TITLE
typing.Collection shouldn't inherit from Container.

### DIFF
--- a/pytype/pytd/builtins/2/typing.pytd
+++ b/pytype/pytd/builtins/2/typing.pytd
@@ -153,7 +153,7 @@ class Sequence(Sized, Iterable[_T], Container[_T], Reversible[_T], Protocol):
   def __reversed__(self) -> Iterator[_T]: ...
 
 
-class Collection(Sized, Iterable[_T], Container[_T], Protocol):
+class Collection(Sized, Iterable[_T], Protocol):
   __slots__ = []
 
 

--- a/pytype/pytd/builtins/3/typing.pytd
+++ b/pytype/pytd/builtins/3/typing.pytd
@@ -153,7 +153,7 @@ class Sequence(Sized, Iterable[_T], Container[_T], Reversible[_T], Protocol):
   def __reversed__(self) -> Iterator[_T]: ...
 
 
-class Collection(Sized, Iterable[_T], Container[_T], Protocol):
+class Collection(Sized, Iterable[_T], Protocol):
   __slots__ = []
 
 

--- a/pytype/tests/py3/test_dict.py
+++ b/pytype/tests/py3/test_dict.py
@@ -70,5 +70,15 @@ class DictTest(test_base.TargetPython3BasicTest):
         return group_dict
     """)
 
+  def testDictValues(self):
+    self.Check("""
+      from typing import Any, Collection
+
+      def take_collection(c: Collection[Any]):
+        return
+
+      take_collection({}.values())
+    """)
+
 
 test_base.main(globals(), __name__ == "__main__")


### PR DESCRIPTION
Despite the documentation
(https://docs.python.org/3/library/collections.abc.html#collections.abc.Collection)
suggesting the class should include the __contains__ method, this is
not actually implemented by (at least) ValuesView (dict_values), which
most definitely _is_ a Collection.