### PR TITLE
Add a top-level __main__.py module

### DIFF
--- a/pytype/__main__.py
+++ b/pytype/__main__.py
@@ -1,0 +1,7 @@
+import sys
+
+from pytype.tools.analyze_project.main import main
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
This allows running pytype as `python -m pytype`.

Fixes #193.