### PR TITLE
Fix UnboundLocalError about 'argument_parser' in Options

### DIFF
--- a/pytype/config.py
+++ b/pytype/config.py
@@ -44,8 +44,8 @@ class Options(object):
     Raises:
       sys.exit(2): bad option or input filenames.
     """
+    argument_parser = make_parser()
     if isinstance(argv_or_options, list):
-      argument_parser = make_parser()
       options = argument_parser.parse_args(argv_or_options)
     else:
       options = argv_or_options


### PR DESCRIPTION
The except clause in Options.__init__() refers to 'argument_parser'
variable which was only defined in an "if" clause. This results in the
following error:

  UnboundLocalError: local variable 'argument_parser' referenced before assignment

Move 'argument_parser' definition at function's global scope.