### PR TITLE
Supporting multiple disabled rules in .cfg files

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ pythonpath =
     .:
     ~/repo2
 
-# Comma separated list of error names to ignore.
+# Comma or space separated list of error names to ignore.
 disable =
     attribute-error
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,7 +211,7 @@ pythonpath =
     .:
     ~/repo2
 
-# Comma separated list of error names to ignore.
+# Comma or space separated list of error names to ignore.
 disable =
     attribute-error
 ```

--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -193,7 +193,7 @@ def generate_sample_config_or_die(filename, pytype_single_args):
   items = dict(ITEMS)
   assert set(_PYTYPE_SINGLE_ITEMS) == set(pytype_single_args)
   for key, item in _PYTYPE_SINGLE_ITEMS.items():
-    if items[key].comment is None:
+    if item.comment is None:
       items[key] = item._replace(default=pytype_single_args[key].default,
                                  comment=pytype_single_args[key].help)
     else:

--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -62,7 +62,9 @@ ITEMS = {
 
 # The missing fields will be filled in by generate_sample_config_or_die.
 _PYTYPE_SINGLE_ITEMS = {
-    'disable': Item(None, 'pyi-error', ArgInfo('--disable', ','.join), None),
+    'disable': Item(
+        None, 'pyi-error', ArgInfo('--disable', ','.join),
+        'Comma or space separated list of error names to ignore.'),
     'report_errors': Item(
         None, 'True', ArgInfo('--no-report-errors', lambda v: not v), None),
     'precise_return': Item(

--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -86,8 +86,8 @@ def string_to_bool(s):
   return s == 'True' if s in ('True', 'False') else s
 
 
-def concate_disabled_rules(s):
-  return ','.join(t for t in s.split('\n') if t)
+def concat_disabled_rules(s):
+  return ','.join(t for t in s.split() if t)
 
 
 def get_python_version(v):
@@ -103,7 +103,7 @@ def make_converters(cwd=None):
       'output': lambda v: file_utils.expand_path(v, cwd),
       'python_version': get_python_version,
       'pythonpath': lambda v: file_utils.expand_pythonpath(v, cwd),
-      'disable': concate_disabled_rules,
+      'disable': concat_disabled_rules,
   }
 
 
@@ -193,8 +193,11 @@ def generate_sample_config_or_die(filename, pytype_single_args):
   items = dict(ITEMS)
   assert set(_PYTYPE_SINGLE_ITEMS) == set(pytype_single_args)
   for key, item in _PYTYPE_SINGLE_ITEMS.items():
-    items[key] = item._replace(default=pytype_single_args[key].default,
-                               comment=pytype_single_args[key].help)
+    if items[key].comment is None:
+      items[key] = item._replace(default=pytype_single_args[key].default,
+                                 comment=pytype_single_args[key].help)
+    else:
+      items[key] = item._replace(default=pytype_single_args[key].default)
 
   # Not using configparser's write method because it doesn't support comments.
 

--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -84,6 +84,10 @@ def string_to_bool(s):
   return s == 'True' if s in ('True', 'False') else s
 
 
+def concate_disabled_rules(s):
+  return ','.join(t for t in s.split('\n') if t)
+
+
 def get_python_version(v):
   return v if v else utils.format_version(sys.version_info[:2])
 
@@ -97,6 +101,7 @@ def make_converters(cwd=None):
       'output': lambda v: file_utils.expand_path(v, cwd),
       'python_version': get_python_version,
       'pythonpath': lambda v: file_utils.expand_pythonpath(v, cwd),
+      'disable': concate_disabled_rules,
   }
 
 

--- a/pytype/tools/analyze_project/config_test.py
+++ b/pytype/tools/analyze_project/config_test.py
@@ -18,6 +18,9 @@ PYTYPE_CFG = """
     /foo/bar:
     baz/quux
   python_version = 2.7
+  disable =
+    import-error
+    module-attr
 """
 
 RANDOM_CFG = """
@@ -42,6 +45,7 @@ class TestBase(unittest.TestCase):
         os.path.join(path, u'baz/quux')
     ])
     self.assertEqual(conf.python_version, u'2.7')
+    self.assertEqual(conf.disable, u'import-error,module-attr')
 
   def _validate_empty_contents(self, conf):
     for k in config.ITEMS:


### PR DESCRIPTION
Currently, in .cfg files, there isn't a documentation mentioning how to set multiple disable rules. After experiments, I found the only valid way is:

```
[pytype]
...
disable = "import-error,module-attr"
```

However, users are expecting the normal config file syntax as:

```
[pytype]
...
disable =
  import-error
  module-attr
```

So, this PR added this support. It is backward compatible. Test case included.

If this project is export-only, see the internal version of this change cl/290806072.