### PR TITLE
Improvements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development',
     ],

--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,7 @@ setup(
         ]
     },
     package_data={'pytype': get_data_files()},
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.8',
     install_requires=[
         'attrs',
         'importlab>=0.5.1',

--- a/setup.py
+++ b/setup.py
@@ -113,19 +113,6 @@ def get_version():
   return about['__version__']
 
 
-def get_install_requires():
-  requires = [
-      'attrs',
-      'importlab (>=0.5.1)',
-      'ninja',
-      'pyyaml (>=3.11)',
-      'six',
-  ]
-  if sys.version_info >= (3, 3):
-    requires.append('typed_ast')
-  return requires
-
-
 copy_typeshed()
 if build_utils:
   e = build_utils.generate_files()
@@ -165,7 +152,14 @@ setup(
         ]
     },
     package_data={'pytype': get_data_files()},
-    install_requires=get_install_requires(),
+    install_requires=[
+        'attrs',
+        'importlab>=0.5.1',
+        'ninja',
+        'pyyaml>=3.11',
+        'six',
+        'typed_ast; python_version >= "3.3"',
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This is a first pass improvement to `setup.py` to take advantage of newer packaging features and bring this package closer into line with current packaging best practices. The two major changes are:

1. Replace conditional logic with environment markers
    
    PEP 496 introduced environment markers, which allow you to declare a dependency conditional on the environment the package is to be installed into. Among other things, this is useful for cross-compilation.

2. Add python_requires matching test matrix
    
    This will prevent `pip` from finding versions of pytype that do not support a given version of Python. Unfortunately, when no python_requires declaration is made, the default is "acceptable for all versions", and so without yanking old versions, `pip install pytype` on unsupported versions will simply fall back to the latest release without a `python_requires` declaration. Alas, this still seems like a win.

I have also updated the trove classifiers to include Python 3.7 support. I was uncertain why this package is tested on 3.5 but not included in the trove classifiers, so I have left it out of the classifiers but included 3.5 in the `python_requires` declaration.