### PR TITLE
Remove pytype's support for implicit None annotations.

### DIFF
--- a/pytype/convert.py
+++ b/pytype/convert.py
@@ -335,14 +335,6 @@ class Converter(utils.VirtualMachineWeakrefMixin):
       assert container.full_name == "__builtin__.dict", container.full_name
       return self._copy_type_parameters(container, "typing.Mapping")
 
-  def optionalize(self, value):
-    """Optionalize the value, if necessary."""
-    assert isinstance(value, abstract.AtomicAbstractValue)
-    none_type = self.vm.convert.none_type
-    if isinstance(value, abstract.Union) and none_type in value.options:
-      return value
-    return abstract.Union((value, none_type), self.vm)
-
   def merge_classes(self, instances):
     """Merge the classes of the given instances.
 

--- a/pytype/function.py
+++ b/pytype/function.py
@@ -75,9 +75,6 @@ class Signature(object):
     self.annotations = annotations
 
   def _postprocess_annotation(self, name, annotation):
-    if (name in self.defaults and
-        self.defaults[name].data == [annotation.vm.convert.none]):
-      annotation = annotation.vm.convert.optionalize(annotation)
     if name == self.varargs_name:
       return annotation.vm.convert.create_new_varargs_value(annotation)
     elif name == self.kwargs_name:

--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -1382,10 +1382,7 @@ def _normal_param(name, param_type, default, kwonly):
   """Return a pytd.Parameter object for a normal argument."""
   if default is not None:
     default_type = _type_for_default(default)
-    if default_type == pytd.NamedType("NoneType"):
-      if param_type is not None:
-        param_type = pytd.UnionType((param_type, default_type))
-    elif param_type is None:
+    if param_type is None and default_type != pytd.NamedType("NoneType"):
       param_type = default_type
   if param_type is None:
     param_type = pytd.AnythingType()

--- a/pytype/pyi/parser_test.py
+++ b/pytype/pyi/parser_test.py
@@ -946,12 +946,10 @@ class FunctionTest(_ParserTestBase):
                "def foo(x = ...) -> int: ...")
     self.check("def foo(x = ...) -> int: ...",
                "def foo(x = ...) -> int: ...")
-    # Default of None will turn declared type into a union.
-    self.check("def foo(x: str = None) -> int: ...",
-               "def foo(x: Optional[str] = ...) -> int: ...",
-               prologue="from typing import Optional")
-    # Other defaults are ignored if a declared type is present.
+    # Defaults are ignored if a declared type is present.
     self.check("def foo(x: str = 123) -> int: ...",
+               "def foo(x: str = ...) -> int: ...")
+    self.check("def foo(x: str = None) -> int: ...",
                "def foo(x: str = ...) -> int: ...")
     # Allow but do not preserve a trailing comma in the param list.
     self.check("def foo(x: int, y: str = ..., z: bool,) -> int: ...",

--- a/pytype/tests/py3/test_annotations.py
+++ b/pytype/tests/py3/test_annotations.py
@@ -957,8 +957,8 @@ class AnnotationTest(test_base.TargetPython3BasicTest):
       self.assertErrorLogIs(errors, [(5, "wrong-arg-types",
                                       r"Foo\[int\].*Foo\[str\]")])
 
-  def testImplicitOptional(self):
-    ty = self.Infer("""\
+  def testNoImplicitOptional(self):
+    ty, errors = self.InferWithErrors("""\
       from typing import Optional, Union
       def f1(x: str = None):
         pass
@@ -972,14 +972,16 @@ class AnnotationTest(test_base.TargetPython3BasicTest):
       f2(None)
       f3(None)
       f4(None)
-    """, deep=False)
+    """)
     self.assertTypesMatchPytd(ty, """
       from typing import Optional, Union
-      def f1(x: Optional[str] = ...) -> None: ...
+      def f1(x: str = ...) -> None: ...
       def f2(x: Optional[str] = ...) -> None: ...
       def f3(x: Optional[str] = ...) -> None: ...
-      def f4(x: Optional[Union[str, int]] = ...) -> None: ...
+      def f4(x: Union[str, int] = ...) -> None: ...
     """)
+    self.assertErrorLogIs(errors, [(10, "wrong-arg-types"),
+                                   (13, "wrong-arg-types")])
 
   def testInferReturn(self):
     ty = self.Infer("""

--- a/pytype/tests/py3/test_generic.py
+++ b/pytype/tests/py3/test_generic.py
@@ -220,7 +220,7 @@ class GenericBasicTest(test_base.TargetPython3BasicTest):
 
   def testPyiOutput(self):
     ty = self.Infer("""
-      from typing import TypeVar, Generic
+      from typing import Optional, TypeVar, Generic
 
       S = TypeVar('S')
       T = TypeVar('T')
@@ -228,7 +228,7 @@ class GenericBasicTest(test_base.TargetPython3BasicTest):
       V = TypeVar('V')
 
       class MyClass(Generic[T, S]):
-        def __init__(self, x: T = None, y: S = None):
+        def __init__(self, x: Optional[T] = None, y: Optional[S] = None):
             pass
 
         def fun(self, x: T, y: S):


### PR DESCRIPTION
PiperOrigin-RevId: 293721487