### PR TITLE
Allow a range to be sliced in Python 3.

### DIFF
--- a/pytype/pytd/builtins/3/__builtin__.pytd
+++ b/pytype/pytd/builtins/3/__builtin__.pytd
@@ -918,7 +918,10 @@ class super(nothing):
 class range(Sequence[int]):
     __slots__ = []
     def __init__(self, stop: int, ...) -> NoneType
+    @overload
     def __getitem__(self, index: int) -> int
+    @overload
+    def __getitem__(self, index: slice) -> range
     def __iter__(self) -> Iterator[int]
     def __len__(self) -> int
     def __reversed__(self, ...) -> Iterator[int]

--- a/pytype/pytd/builtins/3/builtins.pytd
+++ b/pytype/pytd/builtins/3/builtins.pytd
@@ -918,7 +918,10 @@ class super(nothing):
 class range(Sequence[int]):
     __slots__ = []
     def __init__(self, stop: int, ...) -> NoneType
+    @overload
     def __getitem__(self, index: int) -> int
+    @overload
+    def __getitem__(self, index: slice) -> range
     def __iter__(self) -> Iterator[int]
     def __len__(self) -> int
     def __reversed__(self, ...) -> Iterator[int]

--- a/pytype/tests/py3/test_builtins.py
+++ b/pytype/tests/py3/test_builtins.py
@@ -440,6 +440,8 @@ class BuiltinPython3FeatureTest(test_base.TargetPython3FeatureTest):
     ty, errors = self.InferWithErrors("""\
       xrange(3)
       v = range(3)
+      v[0]
+      v[:]
     """)
     self.assertTypesMatchPytd(ty, """
       v = ...  # type: range


### PR DESCRIPTION
Resolves https://github.com/google/pytype/issues/513.

PiperOrigin-RevId: 295241887