### PR TITLE
Note that install is broken on Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,15 @@ interpreter in `$PATH` for the Python version of the code you're analyzing.
 
 Platform support:
 
-* Pytype is currently developed and tested on Linux, which is the main supported
+* Pytype is currently developed and tested on Linux\*, which is the main supported
   platform.
 * Installation on MacOSX requires OSX 10.7 or higher and Xcode v8 or higher.
 * Windows is currently not supported unless you use [WSL][wsl].
+
+<sub>\*
+    Note: Pytype is tested on Ubuntu Linux.
+    On Alpine Linux, installing may fail due to issues with upstream dependencies.
+</sub>
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ Platform support:
 * Windows is currently not supported unless you use [WSL][wsl].
 
 <sub>\*
-    Note: Pytype is tested on Ubuntu Linux.
-    On Alpine Linux, installing may fail due to issues with upstream dependencies.
+Note: On Alpine Linux, installing may fail due to issues with upstream
+dependencies.  See the details of
+<a href="https://github.com/scikit-build/ninja-python-distributions/issues/27">
+this issue</a> for a possible fix.
 </sub>
 
 ## Installing

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,10 +91,15 @@ interpreter in `$PATH` for the Python version of the code you're analyzing.
 
 Platform support:
 
-* Pytype is currently developed and tested on Linux, which is the main supported
+* Pytype is currently developed and tested on Linux\*, which is the main supported
   platform.
 * Installation on MacOSX requires OSX 10.7 or higher and Xcode v8 or higher.
 * Windows is currently not supported unless you use [WSL][wsl].
+
+<sub>\*
+    Note: Pytype is tested on Ubuntu Linux.
+    On Alpine Linux, installing may fail due to issues with upstream dependencies.
+</sub>
 
 ## Installing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,8 +97,10 @@ Platform support:
 * Windows is currently not supported unless you use [WSL][wsl].
 
 <sub>\*
-    Note: Pytype is tested on Ubuntu Linux.
-    On Alpine Linux, installing may fail due to issues with upstream dependencies.
+Note: On Alpine Linux, installing may fail due to issues with upstream
+dependencies.  See the details of
+<a href="https://github.com/scikit-build/ninja-python-distributions/issues/27">
+this issue</a> for a possible fix.
 </sub>
 
 ## Installing


### PR DESCRIPTION
Related:

- https://github.com/scikit-build/ninja-python-distributions/issues/22
- https://github.com/scikit-build/ninja-python-distributions/issues/27
- https://github.com/google/pytype/issues/495

As of 2020-03-28:

```
$ docker container run -it --rm python:3-alpine /bin/sh -c 'python -m pip install pytype'
Collecting pytype
  Downloading pytype-2020.2.6.tar.gz (1.1 MB)
     |████████████████████████████████| 1.1 MB 3.5 MB/s 
Collecting attrs
  Downloading attrs-19.3.0-py2.py3-none-any.whl (39 kB)
Collecting importlab>=0.5.1
  Downloading importlab-0.5.1.tar.gz (19 kB)
Collecting ninja
  Downloading ninja-1.9.0.post1.tar.gz (25 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-99u6fv5a/ninja/setup.py'"'"'; __file__='"'"'/tmp/pip-install-99u6fv5a/ninja/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-99u6fv5a/ninja/pip-egg-info
         cwd: /tmp/pip-install-99u6fv5a/ninja/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-99u6fv5a/ninja/setup.py", line 7, in <module>
        from skbuild import setup
    ModuleNotFoundError: No module named 'skbuild'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Also confirmed this is still the case after a pip downgrade.