### PR TITLE
Call sys.exit() with the return code in build_scripts/pyexe.

### DIFF
--- a/build_scripts/pyexe.py
+++ b/build_scripts/pyexe.py
@@ -36,7 +36,7 @@ import sys
 
 {import_stmt}
 
-{modname}.main()
+sys.exit({modname}.main())
 """
 
 


### PR DESCRIPTION
With this fix, our Travis script will report type-checking failures.