### PR TITLE
Test against 3.8 and master with allowed failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ language: python
 
 matrix:
   include:
-  - python: "3.5"
-  - python: "3.6"
-  - python: "3.7"
+    - python: "3.5"
+    - python: "3.6"
+    - python: "3.7"
+    - python: "3.8"
+    - python: "nightly"
+  allow_failures:
+    - python: "3.8"
+    - python: "nightly"
 
 before_install:
   - sudo apt-get install g++


### PR DESCRIPTION
This adds non-required jobs that will test against 3.8 and the master branch, which should make it easier to determine what needs to be done to add support for those Python versions.

Note: This will currently always fail trivially, because it's excluded in `python_requires`. This will still be beneficial because non-maintainers can modify `setup.cfg` in their PR branches, but they cannot modify `.travis.yml`. A better long-term solution would be to add a workaround that allows installing the package on nominally unsupported versions of Python