### PR TITLE
Add a requirements.txt.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@ frustration later on.
 All submissions, including submissions by project members, require review. We
 use Github pull requests for this purpose.
 
-
 ### Pytype dependencies
 Before you can build and test Pytype, you will have to install a few
 dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Python dependencies for building and testing the pytype source code.
+# Make sure you also install the non-Python dependencies described in
+# https://github.com/google/pytype/blob/master/CONTRIBUTING.md#pytype-dependencies.
+# In particular, use the official ninja package, not the pip distribution.
+attrs
+importlab
+pylint
+pyyaml
+six
+typed_ast


### PR DESCRIPTION
With this, we can run `pip install -r requirements.txt` to get all the
dependencies for building and testing the GitHub code locally.
Previously, I was looking at .travis.yml every time to figure out what
to install.

Based on
https://packaging.python.org/discussions/install-requires-vs-requirements/,
setup.py's install_requires and requirements.txt accomplish different
purposes, so I haven't tried to keep them in sync.

I'm also hoping that adding this file will fix our broken dependency
graph, which currently shows no dependencies and no dependents:
https://help.github.com/en/github/visualizing-repository-data-with-graphs/listing-the-packages-that-a-repository-depends-on.

I also deleted a stray newline in CONTRIBUTING.md, because why not?