### PR TITLE
Use dir() instead of __dict__ to find test methods.

### DIFF
--- a/build_scripts/test_module.py
+++ b/build_scripts/test_module.py
@@ -152,7 +152,7 @@ def _get_members_list(parent_object):
   # We want to create of list of members explicitly as dict.items in
   # Python 3 returns an iterator. Hence, we do not want to be in situation where
   # in the members dict changes during iteration and raises an exception.
-  return list(parent_object.__dict__.items())
+  return [(name, getattr(parent_object, name)) for name in dir(parent_object)]
 
 
 def run_tests_in_class(class_object, options, reporter):


### PR DESCRIPTION
When __dict__ is used, subclasses don't pick up inherited test methods.
Since TargetIndependentTest subclasses test classes to add Python 2
testing, this bug meant that there were a whole bunch of 2and3 tests
that we were running in Python 3 only.