### PR TITLE
Prepare for a PyPI release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 2020.05.13
+* Check attrs default values against annotations.
+* Add an experimental --check-variable-types mode.
+
 Version 2020.05.07
 * Drop support for analyzing Python 3.4.
 * Add special builtins support for filter(None, xs).

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2020.05.07'
+__version__ = '2020.05.13'


### PR DESCRIPTION
The new version of pytype looks good (I'm just waiting for a few more Rosie CLs
to be submitted before releasing it internally), so we can go ahead with the
PyPI release.

PiperOrigin-RevId: 311404665