### PR TITLE
Update __version__ and CHANGELOG for a PyPI release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 2020.06.01
+* Update typeshed pin to commit 5fe6a5b from May 18.
+* Support callback protocols.
+* Get rid of the RemoveInheritedMethods pyi optimisation.
+* (In-progress) Add partial Python 3.8 support.
+
 Version 2020.05.13
 * Check attrs default values against annotations.
 * Add an experimental --check-variable-types mode.

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2020.05.13'
+__version__ = '2020.06.01'


### PR DESCRIPTION
PiperOrigin-RevId: 314201645