### PR TITLE
Autodetect number of jobs with --jobs auto

### DIFF
--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -48,7 +48,8 @@ ITEMS = {
         'Keep going past errors to analyze as many files as possible.'),
     'jobs': Item(
         1, '4', None,
-        'Run N jobs in parallel.'),
+        "Run N jobs in parallel. When 'auto' is used, this will be equivalent "
+        'to the number of CPUs on the host system.'),
     'output': Item(
         '.pytype', '.pytype', None, 'All pytype output goes here.'),
     'pythonpath': Item(

--- a/pytype/tools/analyze_project/parse_args.py
+++ b/pytype/tools/analyze_project/parse_args.py
@@ -10,6 +10,7 @@ from pytype.tools.analyze_project import config
 
 _ARG_PREFIX = '--'
 
+
 def _auto_detect_cpus():
   try:
     return len(os.sched_getaffinity(0))
@@ -18,12 +19,15 @@ def _auto_detect_cpus():
 
 
 def parse_jobs(s):
-  """Parse the --jobs option"""
+  """Parse the --jobs option."""
   if s == 'auto':
     n = _auto_detect_cpus()
     return n if n else 1
   elif s is not None:
     return int(s)
+  else:
+    return None
+
 
 class Parser(arg_parser.Parser):
   """Subclasses Parser to add a config file processor."""


### PR DESCRIPTION
This adds the possibility to autodetect the number of jobs based on the number of available CPU cores on the host system using `pytype --jobs auto`. This allows for a usage similar to [`pytest-xdist`](https://github.com/pytest-dev/pytest-xdist#speed-up-test-runs-by-sending-tests-to-multiple-cpus) which can be useful when using `pytype` in scripts that might run on different systems.