### PR TITLE
Remove no-longer-necessary docker installation step.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Install Docker
-        run: sudo apt-get install -y --no-install-recommends docker
       - name: Pull Docker image
         run: |
           DOCKER_IMAGE="quay.io/pypa/${{ matrix.platform }}"


### PR DESCRIPTION
Building of the manylinux wheel started failing consistently five days ago: https://github.com/google/pytype/actions/runs/170384447. As far as I can tell, what happened is that the ubuntu-latest image was updated to a version in which the docker command-line tool is provided by the moby-cli and moby-engine packages and does not need to be separately installed. (In fact, installing `docker` causes the previous two packages to be uninstalled.)

The MacOS wheels are also failing, but those failures are due to timeouts and the builds intermittently succeed, so I *think* that one's not our fault.