### PR TITLE
Make imports_map_loader_test work with custom $TMPDIR values.

### DIFF
--- a/pytype/imports_map_loader_test.py
+++ b/pytype/imports_map_loader_test.py
@@ -60,19 +60,24 @@ class ImportMapLoaderTest(unittest.TestCase):
       d.create_file("imports_info", "\n".join(imports_map))
       # build_imports_map should strip out the entry for a/__init__.py, leaving
       # the entry for a/b.py intact.
+      expected = [
+          ("%s/a/b" % d.path, "{0}/prefix{0}/a/b.py~suffix".format(d.path)),
+          # These are all added by the last bit of build_imports_map
+          ("__init__", os.devnull),
+          ("%s/__init__" % d.path[1:], os.devnull),
+          ("%s/a/__init__" % d.path[1:], os.devnull),
+      ]
+      path = tempfile.tempdir[1:]
+      while path:
+        expected.append((os.path.join(path, "__init__"), os.devnull))
+        path = os.path.dirname(path)
       six.assertCountEqual(
           self,
           imports_map_loader.build_imports_map(
               d["imports_info"],
               d["a/__init__.py"]).items(),
-          [
-              ("%s/a/b" % d.path, "{0}/prefix{0}/a/b.py~suffix".format(d.path)),
-              # These are all added by the last bit of build_imports_map
-              ("__init__", os.devnull),
-              ("tmp/__init__", os.devnull),
-              ("%s/__init__" % d.path[1:], os.devnull),
-              ("%s/a/__init__" % d.path[1:], os.devnull),
-          ])
+          expected,
+      )
 
   def test_do_not_filter(self):
     with file_utils.Tempdir() as d:


### PR DESCRIPTION
Fixes https://github.com/google/pytype/issues/629.

PiperOrigin-RevId: 323855323