### PR TITLE
Do a PyPI release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 2020.07.30
+* Allow typing.AnyStr to be used to parameterize custom generic classes.
+* FIX: We were occasionally reusing an exhausted generator in Union constructor.
+* Support imported type macros in pyi files.
+* When raising not-supported-yet for Alias = Union[T, ...] set the type to Any.
+
 Version 2020.07.24
 * pyi parser: allow aliases inside a class to values outside the class.
 * Copy annotations instead of modifying them when adding a scope.

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2020.07.24'
+__version__ = '2020.07.30'


### PR DESCRIPTION
For yet another pyi parser fix (https://github.com/google/pytype/issues/626).

PiperOrigin-RevId: 324104646