### PR TITLE
Support TypedDict function-based syntax in pyi files.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Version 2020.08.17
 * Allow `# type: ignore` in more places in pyi files.
+* Support TypedDict function-based syntax in pyi files.
 * Add more developer documentation.
 
 Version 2020.08.10

--- a/pytype/pyi/lexer.lex
+++ b/pytype/pyi/lexer.lex
@@ -55,6 +55,8 @@ typedef pytype::parser::token t;
 \] { --yyextra->bracket_count_; return yytext[0]; }
 \( { ++yyextra->bracket_count_; return yytext[0]; }
 \) { --yyextra->bracket_count_; return yytext[0]; }
+\{ { ++yyextra->bracket_count_; return yytext[0]; }
+\} { --yyextra->bracket_count_; return yytext[0]; }
 
  /* STRING */
  /* TODO(rechen): the string parsing below doesn't handle escaped quotes. */
@@ -101,6 +103,9 @@ typedef pytype::parser::token t;
 "typing.NamedTuple" { return t::NAMEDTUPLE; }
 "namedtuple" { return t::COLL_NAMEDTUPLE; }
 "collections.namedtuple" { return t::COLL_NAMEDTUPLE; }
+"TypedDict" { return t::TYPEDDICT; }
+"typing.TypedDict" { return t::TYPEDDICT; }
+"typing_extensions.TypedDict" { return t::TYPEDDICT; }
 "TypeVar" { return t::TYPEVAR; }
 "typing.TypeVar" { return t::TYPEVAR; }
 

--- a/pytype/pyi/lexer_test.py
+++ b/pytype/pyi/lexer_test.py
@@ -297,6 +297,11 @@ class LexerTest(test_base.UnitTest):
     self.check(["COLL_NAMEDTUPLE"], "namedtuple")
     self.check(["COLL_NAMEDTUPLE"], "collections.namedtuple")
 
+  def test_typeddict(self):
+    self.check(["TYPEDDICT"], "TypedDict")
+    self.check(["TYPEDDICT"], "typing.TypedDict")
+    self.check(["TYPEDDICT"], "typing_extensions.TypedDict")
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/pytype/pyi/parser.h
+++ b/pytype/pyi/parser.h
@@ -34,6 +34,7 @@ enum CallSelector {
   kNewConstant,
   kNewFunction,
   kNewNamedTuple,
+  kNewTypedDict,
   kRegisterClassName,
   kAddTypeVar,
 

--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -1060,6 +1060,28 @@ class _Parser(object):
     self._generated_classes[base_name].append(nt_class)
     return pytd.NamedType(nt_class.name)
 
+  def new_typed_dict(self, name, items, total):
+    """Returns a type for a TypedDict.
+
+    This method is currently called only for TypedDict objects defined via
+    the following function-based syntax:
+
+      Foo = TypeDict('Foo', {'a': int, 'b': str}, total=False)
+
+    rather than the recommended class-based syntax.
+
+    Args:
+      name: the name of the TypedDict instance, e.g., "'Foo'".
+      items: a {key: value_type} dict, e.g., {"'a'": "int", "'b'": "str"}.
+      total: A tuple of a single kwarg, e.g., ("total", NamedType("False")), or
+        None when no kwarg is passed.
+    """
+    # TODO(b/157603915): Add real support for TypedDict.
+    del name, items, total  # unused
+    return pytd.GenericType(
+        pytd.NamedType("typing.Dict"),
+        (pytd.NamedType("str"), pytd.NamedType("typing.Any")))
+
   def register_class_name(self, class_name):
     """Register a class name so that it can shadow aliases."""
     if not self._current_condition.active:

--- a/pytype/pyi/parser_ext.cc
+++ b/pytype/pyi/parser_ext.cc
@@ -45,6 +45,7 @@ static const SelectorEntry<CallSelector> call_attributes[] = {
   {kNewConstant, "new_constant"},
   {kNewFunction, "new_function"},
   {kNewNamedTuple, "new_named_tuple"},
+  {kNewTypedDict, "new_typed_dict"},
   {kRegisterClassName, "register_class_name"},
   {kAddTypeVar, "add_type_var"},
 
@@ -293,6 +294,7 @@ static void add_tokens_dict(PyObject* module) {
   add_token(tokens, "NOTHING",         t::NOTHING);
   add_token(tokens, "NAMEDTUPLE",      t::NAMEDTUPLE);
   add_token(tokens, "COLL_NAMEDTUPLE", t::COLL_NAMEDTUPLE);
+  add_token(tokens, "TYPEDDICT",       t::TYPEDDICT);
   add_token(tokens, "TYPEVAR",         t::TYPEVAR);
 
   // Add dict to module.

--- a/pytype/pyi/parser_test.py
+++ b/pytype/pyi/parser_test.py
@@ -1315,44 +1315,6 @@ class ClassTest(_ParserTestBase):
       class Foo(metaclass=Meta, Bar): ...
       """, 1, "non-keyword arguments cannot follow keyword arguments")
 
-  def test_typed_dict_kwarg(self):
-    self.check("""
-      from typing import TypedDict
-
-      class Foo(TypedDict, total=False): ...
-    """, """
-      from typing import TypedDict
-
-      class Foo(TypedDict): ...
-    """)
-    self.check_error("""
-      class Foo(object, total=False): ...
-    """, 1, "'total' allowed as classdef kwarg only for TypedDict subclasses")
-
-  def test_typing_extensions_typed_dict(self):
-    self.check("""
-      from typing_extensions import TypedDict
-
-      class Foo(TypedDict, total=False): ...
-    """, """
-      import typing_extensions
-
-      from typing_extensions import TypedDict
-
-      class Foo(typing_extensions.TypedDict): ...
-    """)
-
-  def test_multiple_classdef_kwargs(self):
-    self.check("""
-      from typing import TypedDict
-
-      class Foo(TypedDict, total=False, metaclass=Meta): ...
-    """, """
-      from typing import TypedDict
-
-      class Foo(TypedDict, metaclass=Meta): ...
-    """)
-
   def test_shadow_pep484(self):
     self.check("""
       class List:
@@ -2465,6 +2427,94 @@ class LiteralTest(_ParserTestBase):
       from typing_extensions import Literal
 
       x: Literal[42]
+    """)
+
+
+class TypedDictTest(_ParserTestBase):
+
+  def test_assign(self):
+    self.check("""
+      from typing_extensions import TypedDict
+      X = TypedDict('X', {})
+    """, """
+      from typing import Any, Dict
+
+      from typing_extensions import TypedDict
+      X = Dict[str, Any]
+    """)
+
+  def test_assign_with_items(self):
+    self.check("""
+      from typing_extensions import TypedDict
+      X = TypedDict('X', {'a': int, 'b': str})
+    """, """
+      from typing import Any, Dict
+
+      from typing_extensions import TypedDict
+      X = Dict[str, Any]
+    """)
+
+  def test_assign_with_kwarg(self):
+    self.check("""
+      from typing_extensions import TypedDict
+      X = TypedDict('X', {}, total=False)
+    """, """
+      from typing import Any, Dict
+
+      from typing_extensions import TypedDict
+      X = Dict[str, Any]
+    """)
+
+  def test_trailing_comma(self):
+    self.check("""
+      from typing_extensions import TypedDict
+      X = TypedDict('X', {
+          'a': int,
+          'b': str,
+      },)
+    """, """
+      from typing import Any, Dict
+
+      from typing_extensions import TypedDict
+      X = Dict[str, Any]
+    """)
+
+  def test_kwarg(self):
+    self.check("""
+      from typing import TypedDict
+
+      class Foo(TypedDict, total=False): ...
+    """, """
+      from typing import TypedDict
+
+      class Foo(TypedDict): ...
+    """)
+    self.check_error("""
+      class Foo(object, total=False): ...
+    """, 1, "'total' allowed as classdef kwarg only for TypedDict subclasses")
+
+  def test_typing_extensions(self):
+    self.check("""
+      from typing_extensions import TypedDict
+
+      class Foo(TypedDict, total=False): ...
+    """, """
+      import typing_extensions
+
+      from typing_extensions import TypedDict
+
+      class Foo(typing_extensions.TypedDict): ...
+    """)
+
+  def test_multiple_classdef_kwargs(self):
+    self.check("""
+      from typing import TypedDict
+
+      class Foo(TypedDict, total=False, metaclass=Meta): ...
+    """, """
+      from typing import TypedDict
+
+      class Foo(TypedDict, metaclass=Meta): ...
     """)
 
 

--- a/pytype/tests/py3/test_typing.py
+++ b/pytype/tests/py3/test_typing.py
@@ -711,5 +711,30 @@ class TypingTestPython3Feature(test_base.TargetPython3FeatureTest):
       f(collections.OrderedDict(a=0))
     """)
 
+  def test_typed_dict(self):
+    with file_utils.Tempdir() as d:
+      d.create_file("foo.pyi", """
+        from typing_extensions import TypedDict
+        X = TypedDict('X', {'a': int})
+      """)
+      self.CheckWithErrors("""
+        import foo
+        from typing import Dict
+
+        def f1(x: Dict[str, int]):
+          pass
+        def f2(x: Dict[int, str]):
+          pass
+        def f3(x: foo.X):
+          pass
+
+        x = None  # type: foo.X
+
+        f1(x)  # okay
+        f2(x)  # wrong-arg-types
+        f3({'a': 0})  # okay
+        f3({0: 'a'})  # wrong-arg-types
+      """, pythonpath=[d.path])
+
 
 test_base.main(globals(), __name__ == "__main__")


### PR DESCRIPTION
Since we don't support TypedDict yet, the parser simply rewrites TypedDict
to Dict[str, Any].

Fixes https://github.com/google/pytype/issues/637.

PiperOrigin-RevId: 327131566