### PR TITLE
Clean up some lint errors.

### DIFF
--- a/build_scripts/release.py
+++ b/build_scripts/release.py
@@ -31,7 +31,7 @@ RELEASE_MODE = "RELEASE"
 class ReleaseError(Exception):
 
   def __init__(self, msg):
-    super(ReleaseError, self).__init__()
+    super().__init__()
     self.msg = msg
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -11,6 +11,7 @@ ignore=test_data
 # multiple time (only on the command line, not in the configuration file where
 disable=
   abstract-method,
+  c-extension-no-member,
   arguments-differ,
   arguments-out-of-order,
   assigning-non-slot,
@@ -40,10 +41,12 @@ disable=
   no-self-use,
   not-an-iterable,
   protected-access,
+  raise-missing-from,  # https://github.com/google/pytype/issues/656
   relative-import,
   self-assigning-variable,
   signature-differs,
   slots-on-old-class,
+  super-with-arguments,  # https://github.com/google/pytype/issues/656
   too-few-public-methods,
   too-many-ancestors,
   too-many-arguments,


### PR DESCRIPTION
Disable three new errors. c-extension-no-member doesn't seem useful;
super-with-arguments and raise-missing-from we're not ready for because
they assume Python 3-only.

build_scripts/ *is* py3-only, so I fixed an instance of
super-with-arguments there.

For https://github.com/google/pytype/issues/656.