### PR TITLE
Re-enable Python 3-only lint errors.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -41,12 +41,10 @@ disable=
   no-self-use,
   not-an-iterable,
   protected-access,
-  raise-missing-from,  # https://github.com/google/pytype/issues/656
   relative-import,
   self-assigning-variable,
   signature-differs,
   slots-on-old-class,
-  super-with-arguments,  # https://github.com/google/pytype/issues/656
   too-few-public-methods,
   too-many-ancestors,
   too-many-arguments,


### PR DESCRIPTION
Fixes https://github.com/google/pytype/issues/656.