### PR TITLE
Declare Python 3.8 support (whoo!) and add 3.9 to the testing matrix.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           docker image pull "$DOCKER_IMAGE"
       - name: Build manylinux wheels
         env:
-          PYTHON_TAGS: 'cp35-cp35m cp36-cp36m cp37-cp37m'
+          PYTHON_TAGS: 'cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38'
         run: |
           docker container run \
             --rm \
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python_version: [3.5, 3.6, 3.7]
+        python_version: [3.5, 3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ matrix:
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"
+    - python: "3.9-dev"
     - python: "nightly"
   allow_failures:
-    - python: "3.8"
+    - python: "3.9-dev"
     - python: "nightly"
 
 before_install:

--- a/pylintrc
+++ b/pylintrc
@@ -56,6 +56,7 @@ disable=
   too-many-return-statements,
   too-many-statements,
   unbalanced-tuple-unpacking,
+  unsubscriptable-object,
   unused-argument,
   useless-import-alias,
   useless-object-inheritance,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
 


### PR DESCRIPTION
Python 3.9 is "3.9-dev" on Travis:
https://travis-ci.community/t/python-3-9-support/6703.

The m flag for manylinux Python tags is dropped in 3.8:
https://github.com/pypa/manylinux/blob/master/README.rst#manylinux2014.

Since it was trivial to do, I also silenced an incorrect lint error that
shows up in 3.9:
  "Value 'Union' is unsubscriptable (unsubscriptable-object)"
(or sometimes 'Optional').

For https://github.com/google/pytype/issues/440.