### PR TITLE
[WIP] Use `py -x.y` instead of `pythonx.y` for windows.

### DIFF
--- a/pytype/config_test.py
+++ b/pytype/config_test.py
@@ -42,7 +42,7 @@ class ConfigTest(unittest.TestCase):
     opts = config.Options.create(python_version=(2, 7), use_pickled_files=True)
     self.assertEqual(opts.use_pickled_files, True)
     self.assertEqual(opts.python_version, (2, 7))
-    exe, _ = opts.python_exe
+    (exe,), _ = opts.python_exe
     self.assertIn("2.7", exe)
 
   def test_analyze_annotated_check(self):

--- a/pytype/pyc/pyc.py
+++ b/pytype/pyc/pyc.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import tempfile
+from typing import List, Tuple
 
 from pytype import compat
 from pytype import pytype_source_utils
@@ -35,8 +36,9 @@ class CompileError(Exception):
       self.lineno = 1
 
 
-def compile_src_string_to_pyc_string(src, filename, python_version, python_exe,
-                                     mode="exec"):
+def compile_src_string_to_pyc_string(
+    src, filename, python_version, python_exe: Tuple[List[str], List[str]],
+    mode="exec"):
   """Compile Python source code to pyc data.
 
   This may use py_compile if the src is for the same version as we're running,
@@ -81,7 +83,7 @@ def compile_src_string_to_pyc_string(src, filename, python_version, python_exe,
       # We pass -E to ignore the environment so that PYTHONPATH and
       # sitecustomize on some people's systems don't mess with the interpreter.
       exe, flags = python_exe
-      cmd = [exe] + flags + ["-E", "-", fi.name, filename or fi.name, mode]
+      cmd = exe + flags + ["-E", "-", fi.name, filename or fi.name, mode]
 
       compile_script_src = pytype_source_utils.load_pytype_file(COMPILE_SCRIPT)
 

--- a/pytype/tools/environment.py
+++ b/pytype/tools/environment.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+from typing import List
 
 from pytype.pytd import typeshed
 from pytype.tools import runner
@@ -15,11 +16,11 @@ def check_pytype_or_die():
     sys.exit(1)
 
 
-def check_python_version(exe, required):
+def check_python_version(exe: List[str], required):
   """Check if exe is a python executable with the required version."""
   try:
     # python --version outputs to stderr for earlier versions
-    _, out, err = runner.BinaryRun([exe, "--version"]).communicate()  # pylint: disable=unpacking-non-sequence
+    _, out, err = runner.BinaryRun(exe + ["--version"]).communicate()  # pylint: disable=unpacking-non-sequence
     version = out or err
     version = version.decode("utf-8")
     if version.startswith("Python %s" % required):
@@ -30,10 +31,14 @@ def check_python_version(exe, required):
     return False, None
 
 
-def check_python_exe_or_die(required):
+def check_python_exe_or_die(required) -> List[str]:
   """Check if a python executable with the required version is in path."""
   error = []
-  for exe in ["python", "python%s" % required]:
+  if sys.platform == "win32":
+    possible_exes = (["py"], ["py", "-%s" % required])
+  else:
+    possible_exes = (["python"], ["python%s" % required])
+  for exe in possible_exes:
     valid, out = check_python_version(exe, required)
     if valid:
       return exe

--- a/pytype/utils.py
+++ b/pytype/utils.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import threading
 import types
+from typing import List, Tuple
 import weakref
 
 from pytype import pytype_source_utils
@@ -154,7 +155,7 @@ def concat_tuples(tuples):
   return tuple(itertools.chain.from_iterable(tuples))
 
 
-def get_python_exe(python_version):
+def get_python_exe(python_version) -> Tuple[List[str], List[str]]:
   """Find a python executable to use.
 
   Arguments:
@@ -165,9 +166,11 @@ def get_python_exe(python_version):
   # Use custom interpreters, if provided, in preference to the ones in $PATH
   custom_python_exe = pytype_source_utils.get_custom_python_exe(python_version)
   if custom_python_exe:
-    python_exe = custom_python_exe
+    python_exe = [custom_python_exe]
+  elif sys.platform == "win32":
+    python_exe = ["py", "-%d.%d" % python_version]
   else:
-    python_exe = "python%d.%d" % python_version
+    python_exe = ["python%d.%d" % python_version]
   if USE_ANNOTATIONS_BACKPORT and python_version == (2, 7):
     flags = ["-T"]
   else:
@@ -175,7 +178,7 @@ def get_python_exe(python_version):
   return python_exe, flags
 
 
-def get_python_exe_version(python_exe):
+def get_python_exe_version(python_exe: List[str]):
   """Determine the major and minor version of given Python executable.
 
   Arguments:
@@ -185,7 +188,7 @@ def get_python_exe_version(python_exe):
   """
   try:
     python_exe_version = subprocess.check_output(
-        [python_exe, "-V"], stderr=subprocess.STDOUT).decode()
+        python_exe + ["-V"], stderr=subprocess.STDOUT).decode()
   except subprocess.CalledProcessError:
     return None
 

--- a/pytype/utils_test.py
+++ b/pytype/utils_test.py
@@ -104,7 +104,7 @@ class UtilsTest(unittest.TestCase):
       self.assertEqual(expected, utils.parse_exe_version_string(version_str))
 
   def test_get_python_exe_version(self):
-    version = utils.get_python_exe_version("python")
+    version = utils.get_python_exe_version(["python"])
     self.assertIsInstance(version, tuple)
     self.assertEqual(len(version), 2)
 


### PR DESCRIPTION
Although pytype doesn't support windows, the typeshed pytype_test used
to work under windows when --python_exe could be used to pass in the
path to the python interpreter. I broke the test when I removed this
flag (oops). Attempting to fix it by doing a sys.platform check and
using the python launcher for windows
(https://docs.python.org/3/using/windows.html#python-launcher-for-windows).