### PR TITLE
Switch the Travis build environment to Focal Fossa.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial  # Python3.7 virtualenv is available only on Travis Xenial VMs.
+dist: focal  # Ubuntu 20.04 build environment
 
 git:
   submodules: true
@@ -23,17 +23,7 @@ before_install:
   - sudo apt-get install cmake
   - sudo apt-get install bison
   - sudo apt-get install flex
-
-# We need to install python3.6 and python3.7 packages from a third party
-# repo as they are not available on standard Ubuntu Xenial.
-addons:
-  apt:
-    sources:
-    - sourceline: 'ppa:deadsnakes/ppa'
-    packages:
-    - python3.6  # To compile targets with a 3.6 compiler.
-    - python3.6-dev  # To build host extension modules under 3.6
-    - python3.7-dev  # To build host extension modules under 3.7
+  - sudo apt-get install python2-minimal
 
 install:
   - pip install attrs
@@ -44,5 +34,5 @@ install:
   - pip install six
   - pip install typed_ast
 
-script: 
+script:
   - python build_scripts/travis_script.py


### PR DESCRIPTION
My previous cmake change worked fine locally but failed on Travis once I
tried to pull in a no-srcs cc_library. Turns out that the cmake version
in most of Travis's build environments is quite old, but Focal Fossa is
nice and modern (so modern that we don't need to separately install
Python 3.6 and 3.7 but do need to install 2.7!).