### PR TITLE
Require ninja 1.10.0.post2.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages =
 install_requires =
     attrs
     importlab>=0.5.1
-    ninja
+    ninja>=1.10.0.post2
     pyyaml>=3.11
     six
     typed_ast


### PR DESCRIPTION
pytype requires this version of ninja as of a couple weeks ago, but I
forgot to include the version requirement in setup.cfg, with the result
that users can end up in a broken state if they install pytype in an
environment that already has an older ninja version installed.

For https://github.com/google/pytype/issues/685.