### PR TITLE
Use list comprehensions for flattening (#693)

### DIFF
--- a/pytype/pytd/visitors.py
+++ b/pytype/pytd/visitors.py
@@ -1235,9 +1235,9 @@ class ExpandSignatures(Visitor):
       Function with the new signatures.
     """
 
-    # concatenate return value(s) from VisitSignature
-    signatures = sum([ExpandSignature(s) for s in f.signatures], [])
-    return f.Replace(signatures=tuple(signatures))
+    # flatten return value(s) from VisitSignature
+    signatures = tuple(ex for s in f.signatures for ex in ExpandSignature(s))  # pylint: disable=g-complex-comprehension
+    return f.Replace(signatures=signatures)
 
 
 class AdjustTypeParameters(Visitor):

--- a/pytype/typegraph/cfg_utils.py
+++ b/pytype/typegraph/cfg_utils.py
@@ -105,8 +105,8 @@ def _deep_values_list_product(values_list, seen, complexity_limit):
   """Take the deep Cartesian product of a list of list of Values."""
   result = []
   for row in itertools.product(*(values for values in values_list if values)):
-    extra_params = sum([entry.data.unique_parameter_values()
-                        for entry in row if entry not in seen], [])
+    extra_params = [value for entry in row if entry not in seen  # pylint: disable=g-complex-comprehension
+                    for value in entry.data.unique_parameter_values()]
     extra_values = (extra_params and
                     _deep_values_list_product(extra_params, seen.union(row),
                                               complexity_limit))


### PR DESCRIPTION
This PR changes the visitor and typegraph utils to use list comprehensions for flattening nested sequences instead of `sum([...], [])` which can be slow for large inputs. This should improve readability and also slightly improve performance.

Resolves #693

PiperOrigin-RevId: 335062627