### PR TITLE
Mention requirements.txt in CONTRUBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,14 @@ dependencies.
    Hence, to run these tests, you will need Python 2.7 and Python 3.x
    (preferably 3.6+) interpreters installed on your system.
 
+Required Python packages are listed in the [requirements.txt](requirements.txt)
+file in this repository. They can be installed with pip with the following
+command:
+
+```shell
+pip install -r requirements.txt
+```
+
 The Pytype Git repository also contains few Git submodules. Before building
 the `pytype` executable or running tests, one has to ensure that the submodules
 are up to date. This can be done with the following command:


### PR DESCRIPTION
It comes obvious when building pytype that these are required but was never mentioned in the CONTRIBUTING guide.