### PR TITLE
Stop manually downloading cmake to fix manylinux wheel build.

### DIFF
--- a/build_scripts/wheels/manylinux.sh
+++ b/build_scripts/wheels/manylinux.sh
@@ -22,18 +22,6 @@ untar() {
   rm -vf "${1}.tar.gz"
 }
 
-# Install CMake
-pushd /usr/local/share
-if [[ "$(arch)" != "x86_64" ]]; then
-  echo "Only supported for x86_64 arch, not $(arch)" >&2
-  exit 1
-fi
-curl -sSL \
-  -o cmake.tar.gz \
-  "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
-untar cmake
-ln -s "$(pwd)/cmake/bin/cmake" /usr/local/bin/cmake
-
 # Install ninja/ninja-build (requires CMake)
 curl -sSL \
   -o ninja.zip \


### PR DESCRIPTION
manylinux wheel build is failing with
  ln: failed to create symbolic link ‘/usr/local/bin/cmake’: File exists

I figured this out by going to Settings > Secrets and adding an "ACTIONS_STEP_DEBUG" secret with value "true", which gave us more verbose logs that included the above failure line.