### PR TITLE
Migrate away from set-env.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Pull Docker image
         run: |
           DOCKER_IMAGE="quay.io/pypa/${{ matrix.platform }}"
-          echo "::set-env name=DOCKER_IMAGE::$DOCKER_IMAGE"
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
           docker image pull "$DOCKER_IMAGE"
       - name: Build manylinux wheels
         env:


### PR DESCRIPTION
Our latest Build Wheels run included a deprecation warning:
https://github.com/google/pytype/actions/runs/296426515.

The non-deprecated way to set an environment variable is:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable.