### PR TITLE
Drop support for running pytype under Python 3.5.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           docker image pull "$DOCKER_IMAGE"
       - name: Build manylinux wheels
         env:
-          PYTHON_TAGS: 'cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38'
+          PYTHON_TAGS: 'cp36-cp36m cp37-cp37m cp38-cp38'
         run: |
           docker container run \
             --rm \
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python_version: [3.5, 3.6, 3.7, 3.8]
+        python_version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: python
 
 matrix:
   include:
-    - python: "3.5"
     - python: "3.6"
     - python: "3.7"
     - python: "3.8"

--- a/build_scripts/wheels/manylinux.sh
+++ b/build_scripts/wheels/manylinux.sh
@@ -11,7 +11,6 @@ fi
 yum install -y gettext-devel python3-devel # gettext is for flex
 
 # TODO: what should be the update cadence for these?
-CMAKE_VERSION='3.17.2'
 NINJA_VERSION='1.10.0'
 BISON_VERSION='3.6'
 FLEX_VERSION='2.6.4'

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -27,7 +26,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=3.5, <3.9
+python_requires = >=3.6, <3.9
 packages =
     find:
 install_requires =


### PR DESCRIPTION
Python 3.5 has reached end-of-life; dropping support for host 3.5 allows us to use shiny new 3.6 features in our code.

I noticed that I had accidentally left an unused CMAKE_VERSION variable in a wheel script in a previous PR, so I took the opportunity to delete it.