### PR TITLE
Add pybind11 as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "cpython"]
 	path = cpython
 	url = https://github.com/python/cpython.git
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11


### PR DESCRIPTION
This is necessary in order to use pybind11's CMake rules.