### PR TITLE
fix: simplifiy pybind11 usage

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,4 @@ include LICENSE
 include pyproject.toml
 include pytype/pyi/*
 include pytype/test_data/*
-graft pybind11/pybind11
-graft pybind11/include
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include LICENSE
 include pyproject.toml
 include pytype/pyi/*
 include pytype/test_data/*
+graft pybind11/pybind11
+graft pybind11/include

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "ninja", "wheel"]
+requires = ["setuptools>=40.8.0", "ninja", "wheel", "pybind11==2.6.0rc3"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 attrs
 importlab
 ninja
-pybind11
+pybind11>=2.6.0rc3
 pylint
 pyyaml
 six

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,18 @@ import re
 import shutil
 import sys
 
-from setuptools import setup  # pylint: disable=g-multiple-import
+from setuptools import setup
 
 # Path to directory containing setup.py
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the pybind11 setup helpers
+#
+# This is appended, so if already available in site-packages, that is used
+# instead
 sys.path.append(os.path.join(here, "pybind11"))
-try:
-    from pybind11.setup_helpers import Pybind11Extension
-except ImportError:
-    print("pybind11 missing, probably a source checkout without submodules?")
-    raise
+
+from pybind11.setup_helpers import Pybind11Extension  # pylint: disable=g-import-not-at-top
 
 del sys.path[-1]
 

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,20 @@ import re
 import shutil
 import sys
 
-from setuptools import setup, Extension  # pylint: disable=g-multiple-import
+from setuptools import setup  # pylint: disable=g-multiple-import
 
 # Path to directory containing setup.py
 here = os.path.abspath(os.path.dirname(__file__))
+
+# Get the pybind11 setup helpers
+sys.path.append(os.path.join(here, "pybind11"))
+try:
+    from pybind11.setup_helpers import Pybind11Extension
+except ImportError:
+    print("pybind11 missing, probably a source checkout without submodules?")
+    raise
+
+del sys.path[-1]
 
 try:
   # The repository root is not on the pythonpath with PEP 517 builds
@@ -29,44 +39,27 @@ except ImportError:
 
 def get_parser_ext():
   """Get the parser extension."""
+  extra_compile_args = []
   # We need some platform-dependent compile args for the C extensions.
   if sys.platform == 'win32':
     # windows does not have unistd.h; lex/yacc needs this define.
-    extra_compile_args = ['-DYY_NO_UNISTD_H']
-    extra_link_args = []
-  elif sys.platform == 'darwin':
-    # clang on darwin requires some extra flags, which gcc does not support
-    extra_compile_args = ['-std=c++11', '-stdlib=libc++']
-    extra_link_args = ['-stdlib=libc++']
-  else:
-    extra_compile_args = ['-std=c++11']
-    extra_link_args = []
-  return Extension(
+    extra_compile_args.append('-DYY_NO_UNISTD_H')
+
+  return Pybind11Extension(
       'pytype.pyi.parser_ext',
       sources=[
           'pytype/pyi/parser_ext.cc',
           'pytype/pyi/lexer.lex.cc',
           'pytype/pyi/parser.tab.cc',
       ],
+      cxx_std=11,
       extra_compile_args=extra_compile_args,
-      extra_link_args=extra_link_args
   )
 
 
 def get_typegraph_ext():
   """Generates the typegraph extension."""
-  if sys.platform == 'win32':
-    # At this time, windows requires no additional flags.
-    extra_compile_args = []
-    extra_link_args = []
-  elif sys.platform == 'darwin':
-    # clang on darwin requires some extra flags, which gcc does not support
-    extra_compile_args = ['-std=c++11', '-stdlib=libc++']
-    extra_link_args = ['-stdlib=libc++']
-  else:
-    extra_compile_args = ['-std=c++11']
-    extra_link_args = []
-  return Extension(
+  return Pybind11Extension(
     'pytype.typegraph.cfg',
     sources=[
       "pytype/typegraph/cfg.cc",
@@ -85,8 +78,7 @@ def get_typegraph_ext():
       "pytype/typegraph/solver.h",
       "pytype/typegraph/typegraph.h",
     ],
-    extra_compile_args=extra_compile_args,
-    extra_link_args=extra_link_args,
+    cxx_std=11,
   )
 
 def copy_typeshed():

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 # instead
 sys.path.append(os.path.join(here, "pybind11"))
 
-from pybind11.setup_helpers import Pybind11Extension  # pylint: disable=g-import-not-at-top
-
-del sys.path[-1]
+from pybind11.setup_helpers import Pybind11Extension  # pylint: disable=g-import-not-at-top,wrong-import-position
 
 try:
   # The repository root is not on the pythonpath with PEP 517 builds
@@ -45,6 +43,8 @@ def get_parser_ext():
     # windows does not have unistd.h; lex/yacc needs this define.
     extra_compile_args.append('-DYY_NO_UNISTD_H')
 
+  # This is a setuptools.Extension, with an added include for pybind11, a few
+  # flags, and a cxx_std setting.
   return Pybind11Extension(
       'pytype.pyi.parser_ext',
       sources=[


### PR DESCRIPTION
This is a suggestion for using pybind11 via submodule. pyproject.toml is more elegant, but does require Pip 10+. I can switch to that if requested. Follow up on #714. I don't know all the details of building from scratch (It wants bison 3), but this should be close, I think. CC @rwgk .

I did not include ParallelCompile, but that might also be useful, I think.
