### PR TITLE
Fix the Build MacOS wheels actions.

### DIFF
--- a/build_scripts/wheels/macos.sh
+++ b/build_scripts/wheels/macos.sh
@@ -2,6 +2,8 @@
 
 set -eux
 
+brew untap local/openssl
+brew untap local/python2
 brew update
 python -V
 brew install -v bison || brew upgrade bison


### PR DESCRIPTION
Our build wheels workflow started failing again. I found a workaround in https://github.com/actions/virtual-environments/issues/1811. I suspect that at some point the workflow will fail again, and we'll have to remove the "brew untap" lines =P