### PR TITLE
Fix pip install errors.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include LICENSE
 include pyproject.toml
 include pytype/pyi/*
 include pytype/test_data/*
-
+include pytype/typegraph/*


### PR DESCRIPTION
I was getting errors about cfg_logging.h being missing when trying to
test a new release; this change seems to fix the issue.

I'm still seeing some odd dynamic import failure, but python3.7 on my
machine also appears to be half-broken right now, so I have no idea if
the issue is with the pytype code or my environment.