### PR TITLE
Do a PyPI release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 2020.11.12
+* Support `# type: ignore[errorcode, ...]` in pyi files.
+* Always allow classes to match typing.Hashable.
+* Fix a bug in pytype's handling of Literal[<str>].
+
 Version 2020.11.03
 * Drop support for running pytype under Python 3.5.
 * Add a dependency on pybind11 for new typegraph metrics.

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2020.11.03'
+__version__ = '2020.11.12'


### PR DESCRIPTION
The Build Failures table is still almost suspiciously empty, so it's a great
time to do a release.

PiperOrigin-RevId: 342085198