### PR TITLE
Updated the Tests badge to show build status from travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Tests](https://travis-ci.org/google/pytype.svg?branch=master)](https://travis-ci.org/google/pytype)
+[![Tests](https://travis-ci.com/google/pytype.svg?branch=master)](https://travis-ci.com/google/pytype)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/pytype)](https://pypi.org/project/pytype/#files)
 
 # pytype - 🦆✔


### PR DESCRIPTION
travis-ci.org is going to shut down on **December 31st, 2020**, repository should be migrated to travis-ci.com as mentioned here in docs: https://docs.travis-ci.com/user/migrate/open-source-repository-migration

Once we've migrated to travis-ci.com, we would need to update the tests status badge to show status from travis-ci.com.