### PR TITLE
Improve GitHub Actions workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,12 @@
 # - Don't run this on every push ('on' param)
 
 name: Build wheels
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
 jobs:
   manylinux_wheels:
     name: Python ${{ matrix.python_tag }} ${{ matrix.platform }} wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
 
     - name: Run Tests
       if: matrix.python-version != '3.9-dev'
-      run: python build_scripts/travis_script.py
+      run: python build_scripts/ci_script.py
 
     - name: Run Tests for python 3.9
       if: matrix.python-version == '3.9-dev'
-      run: python build_scripts/travis_script.py || exit 0
+      run: python build_scripts/ci_script.py || exit 0

--- a/build_scripts/ci_script.py
+++ b/build_scripts/ci_script.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""A simple script to run Travis build steps."""
+"""A simple script to run CI build steps."""
 
 from __future__ import print_function
 


### PR DESCRIPTION
Follow-up to https://github.com/google/pytype/pull/743:

* Renames travis_script to ci_script, now that we're no longer using Travis.
* Makes sure both workflows run on PRs and don't run unnecessarily on pushes to non-master branches. Also adds a workflow_dispatch trigger so they can be manually run.