### PR TITLE
Fix MacOS wheel builds.

### DIFF
--- a/build_scripts/wheels/macos.sh
+++ b/build_scripts/wheels/macos.sh
@@ -6,6 +6,8 @@ brew update
 python -V
 brew install -v bison || brew upgrade bison
 brew install -v cmake || brew upgrade cmake
+# temporary workaround for https://github.com/actions/virtual-environments/issues/2428
+rm -rf /usr/local/bin/2to3
 brew install -v ninja || brew upgrade ninja
 python -m pip install -U pip setuptools wheel
 CMAKE_PREFIX_PATH="$(brew --prefix bison)"


### PR DESCRIPTION
Homebrew was recently updated
(https://github.com/actions/virtual-environments/issues/2415),
introducing a bug related to 2to3:
https://github.com/actions/virtual-environments/issues/2428. I applied
the workaround recommended in the issue.