### PR TITLE
Export the typed_ast pyi parser to github.

### DIFF
--- a/pytype/pyi/typed_ast/ast_parser.py
+++ b/pytype/pyi/typed_ast/ast_parser.py
@@ -1,0 +1,637 @@
+# python3
+
+"""Parse a pyi file using typed_ast."""
+
+import hashlib
+import sys
+
+import typing
+from typing import Any, List, Optional, Tuple, Union
+
+import dataclasses
+
+from pytype import utils
+from pytype.ast import debug
+from pytype.pyi.typed_ast import classdef
+from pytype.pyi.typed_ast import conditions
+from pytype.pyi.typed_ast import definitions
+from pytype.pyi.typed_ast import function
+from pytype.pyi.typed_ast import modules
+from pytype.pyi.typed_ast import types
+from pytype.pyi.typed_ast import visitor
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import pep484
+from pytype.pytd import pytd
+from pytype.pytd import visitors
+
+from typed_ast import ast3
+
+
+_DEFAULT_PLATFORM = "linux"
+
+
+#------------------------------------------------------
+# imports
+
+
+def _tuple_of_import(alias: ast3.AST) -> Tuple[str, str]:
+  """Convert a typedast import into one that add_import expects."""
+  if alias.asname is None:
+    return alias.name
+  return alias.name, alias.asname
+
+
+def _import_from_module(module: Optional[str], level: int) -> str:
+  """Convert a typedast import's 'from' into one that add_import expects."""
+  if module is None:
+    return {1: "__PACKAGE__", 2: "__PARENT__"}[level]
+  prefix = "." * level
+  return prefix + module
+
+
+#------------------------------------------------------
+# typevars
+
+
+@dataclasses.dataclass
+class _TypeVar:
+  """Internal representation of typevars."""
+
+  name: str
+  bound: Optional[str]
+  constraints: List[Any]
+
+  @classmethod
+  def from_call(cls, node: ast3.AST) -> "_TypeVar":
+    """Construct a _TypeVar from an ast.Call node."""
+    name, *constraints = node.args
+    bound = None
+    # 'bound' is the only keyword argument we currently use.
+    # TODO(rechen): We should enforce the PEP 484 guideline that
+    # len(constraints) != 1. However, this guideline is currently violated
+    # in typeshed (see https://github.com/python/typeshed/pull/806).
+    kws = {x.arg for x in node.keywords}
+    extra = kws - {"bound", "covariant", "contravariant"}
+    if extra:
+      raise ParseError("Unrecognized keyword(s): %s" % ", ".join(extra))
+    for kw in node.keywords:
+      if kw.arg == "bound":
+        bound = kw.value
+    return cls(name, bound, constraints)
+
+
+#------------------------------------------------------
+# pytd utils
+
+#------------------------------------------------------
+# Main tree visitor and generator code
+
+
+def _attribute_to_name(node: ast3.Attribute) -> ast3.Name:
+  """Recursively convert Attributes to Names."""
+  val = node.value
+  if isinstance(val, ast3.Name):
+    prefix = val.id
+  elif isinstance(val, ast3.Attribute):
+    prefix = _attribute_to_name(val).id
+  elif isinstance(val, (pytd.NamedType, pytd.Module)):
+    prefix = val.name
+  else:
+    msg = "Unexpected attribute access on %r [%s]" % (val, type(val))
+    raise ParseError(msg)
+  return ast3.Name(prefix + "." + node.attr)
+
+
+class AnnotationVisitor(visitor.BaseVisitor):
+  """Converts typed_ast annotations to pytd."""
+
+  def show(self, node):
+    print(debug.dump(node, ast3, include_attributes=False))
+
+  def convert_late_annotation(self, annotation):
+    try:
+      # Late annotations may need to be parsed into an AST first
+      if annotation.isalpha():
+        return self.defs.new_type(annotation)
+      a = ast3.parse(annotation)
+      # Unwrap the module the parser puts around the source string
+      typ = a.body[0].value
+      return self.visit(typ)
+    except ParseError as e:
+      # Clear out position information since it is relative to the typecomment
+      e.clear_position()
+      raise e
+
+  def visit_Tuple(self, node):
+    return tuple(node.elts)
+
+  def visit_List(self, node):
+    return list(node.elts)
+
+  def visit_Name(self, node):
+    if self.subscripted and (node is self.subscripted[-1]):
+      # This is needed because
+      #   Foo[X]
+      # parses to
+      #   Subscript(Name(id = Foo), Name(id = X))
+      # so we see visit_Name(Foo) before visit_Subscript(Foo[X]).
+      # If Foo resolves to a generic type we want to know if it is being passed
+      # params in this context (in which case we simply resolve the type here,
+      # and create a new type when we get the param list in visit_Subscript) or
+      # if it is just being used as a bare Foo, in which case we need to create
+      # the new type Foo[Any] below.
+      return self.defs.resolve_type(node.id)
+    else:
+      return self.defs.new_type(node.id)
+
+  def enter_Subscript(self, node):
+    if isinstance(node.value, ast3.Attribute):
+      node.value = _attribute_to_name(node.value).id
+    self.subscripted.append(node.value)
+
+  def visit_Subscript(self, node):
+    params = node.slice.value
+    if type(params) is not tuple:  # pylint: disable=unidiomatic-typecheck
+      params = (params,)
+    return self.defs.new_type(node.value, params)
+
+  def leave_Subscript(self, node):
+    self.subscripted.pop()
+
+  def visit_Attribute(self, node):
+    annotation = _attribute_to_name(node).id
+    return self.defs.new_type(annotation)
+
+  def visit_BoolOp(self, node):
+    if isinstance(node.op, ast3.Or):
+      raise ParseError("Deprecated syntax `x or y`; use `Union[x, y]` instead")
+    else:
+      raise ParseError(f"Unexpected operator {node.op}")
+
+
+def _flatten_splices(body: List[Any]) -> List[Any]:
+  """Flatten a list with nested Splices."""
+  if not any(isinstance(x, Splice) for x in body):
+    return body
+  out = []
+  for x in body:
+    if isinstance(x, Splice):
+      # This technically needn't be recursive because of how we build Splices
+      # but better not to have the class assume that.
+      out.extend(_flatten_splices(x.body))
+    else:
+      out.append(x)
+  return out
+
+
+class Splice:
+  """Splice a list into a node body."""
+
+  def __init__(self, body):
+    self.body = _flatten_splices(body)
+
+  def __str__(self):
+    return "Splice(\n" + ",\n  ".join([str(x) for x in self.body]) + "\n)"
+
+  def __repr__(self):
+    return str(self)
+
+
+class GeneratePytdVisitor(visitor.BaseVisitor):
+  """Converts a typed_ast tree to a pytd tree."""
+
+  def __init__(self, src, filename, module_name, version, platform):
+    defs = definitions.Definitions(modules.Module(filename, module_name))
+    super().__init__(defs=defs, filename=filename)
+    self.src_code = src
+    self.module_name = module_name
+    self.version = version
+    self.platform = platform or _DEFAULT_PLATFORM
+    self.level = 0
+    self.in_function = False  # pyi will not have nested defs
+    self.annotation_visitor = AnnotationVisitor(defs=defs, filename=filename)
+
+  def show(self, node):
+    print(debug.dump(node, ast3, include_attributes=False))
+
+  def convert_node(self, node):
+    # Converting a node via a visitor will convert the subnodes, but if the
+    # argument node itself needs conversion, we need to use the pattern
+    #   node = annotation_visitor.visit(node)
+    # However, the AnnotationVisitor returns None if it does not trigger on the
+    # root node it is passed, so call it via this method instead.
+    ret = self.annotation_visitor.visit(node)
+    return ret if ret is not None else node
+
+  def convert_node_annotations(self, node):
+    """Transform type annotations to pytd."""
+    if getattr(node, "annotation", None):
+      node.annotation = self.convert_node(node.annotation)
+    elif getattr(node, "type_comment", None):
+      node.type_comment = self.annotation_visitor.convert_late_annotation(
+          node.type_comment)
+
+  def resolve_name(self, name):
+    """Resolve an alias or create a NamedType."""
+    return self.defs.type_map.get(name) or pytd.NamedType(name)
+
+  def visit_Module(self, node):
+    node.body = _flatten_splices(node.body)
+    return self.defs.build_type_decl_unit(node.body)
+
+  def visit_Pass(self, node):
+    return self.defs.ELLIPSIS
+
+  def visit_Expr(self, node):
+    # Handle some special cases of expressions that can occur in class and
+    # module bodies.
+    if node.value == self.defs.ELLIPSIS:
+      # class x: ...
+      return node.value
+    elif types.Constant.is_str(node.value):
+      # docstrings
+      return Splice([])
+
+  def visit_arg(self, node):
+    self.convert_node_annotations(node)
+
+  def _preprocess_decorator_list(self, node):
+    decorators = []
+    for d in node.decorator_list:
+      if isinstance(d, ast3.Name):
+        decorators.append(d.id)
+      elif isinstance(d, ast3.Attribute):
+        decorators.append(f"{d.value.id}.{d.attr}")
+      else:
+        raise ParseError(f"Unexpected decorator: {d}")
+    node.decorator_list = decorators
+
+  def _preprocess_function(self, node):
+    node.args = self.convert_node(node.args)
+    node.returns = self.convert_node(node.returns)
+    self._preprocess_decorator_list(node)
+    node.body = _flatten_splices(node.body)
+
+  def visit_FunctionDef(self, node):
+    self._preprocess_function(node)
+    return function.NameAndSig.from_function(node, False)
+
+  def visit_AsyncFunctionDef(self, node):
+    self._preprocess_function(node)
+    return function.NameAndSig.from_function(node, True)
+
+  def new_alias_or_constant(self, name, value):
+    """Build an alias or constant."""
+    # This is here rather than in _Definitions because we need to build a
+    # constant or alias from a partially converted typed_ast subtree.
+    if name == "__slots__":
+      if not (isinstance(value, ast3.List) and
+              all(types.Constant.is_str(x) for x in value.elts)):
+        raise ParseError("__slots__ must be a list of strings")
+      return types.SlotDecl(tuple([x.value for x in value.elts]))
+    elif isinstance(value, types.Constant):
+      return pytd.Constant(name, value.to_pytd())
+    elif isinstance(value, types.Ellipsis):
+      return pytd.Constant(name, pytd.AnythingType())
+    elif isinstance(value, pytd.NamedType):
+      res = self.defs.resolve_type(value.name)
+      return pytd.Alias(name, res)
+    elif isinstance(value, ast3.List):
+      if name != "__all__":
+        raise ParseError("Only __slots__ and __all__ can be literal lists")
+      return pytd.Constant(name, types.pytd_list("str"))
+    elif isinstance(value, ast3.Tuple):
+      # TODO(mdemello): Consistent with the current parser, but should it
+      # properly be Tuple[Type]?
+      return pytd.Constant(name, pytd.NamedType("tuple"))
+    elif isinstance(value, ast3.Name):
+      value = self.defs.resolve_type(value.id)
+      return pytd.Alias(name, value)
+    else:
+      # TODO(mdemello): add a case for TypeVar()
+      # Convert any complex type aliases
+      value = self.convert_node(value)
+      return pytd.Alias(name, value)
+
+  def enter_AnnAssign(self, node):
+    self.convert_node_annotations(node)
+
+  def visit_AnnAssign(self, node):
+    name = node.target.id
+    typ = node.annotation
+    val = self.convert_node(node.value)
+    if val and not types.is_any(val):
+      msg = f"Default value for {name}: {typ.name} can only be '...', got {val}"
+      raise ParseError(msg)
+    return pytd.Constant(name, typ)
+
+  def visit_Assign(self, node):
+    targets = node.targets
+    if len(targets) > 1 or isinstance(targets[0], ast3.Tuple):
+      msg = "Assignments must be of the form 'name = value'"
+      raise ParseError(msg)
+    self.convert_node_annotations(node)
+    target = targets[0]
+    name = target.id
+
+    # Record and erase typevar definitions.
+    if isinstance(node.value, _TypeVar):
+      self.defs.add_type_var(name, node.value)
+      return Splice([])
+
+    if node.type_comment:
+      # TODO(mdemello): can pyi files have aliases with typecomments?
+      ret = pytd.Constant(name, node.type_comment)
+    else:
+      ret = self.new_alias_or_constant(name, node.value)
+
+    if self.in_function:
+      # Should never happen, but this keeps pytype happy.
+      if isinstance(ret, types.SlotDecl):
+        raise ParseError("Cannot change the type of __slots__")
+      return function.Mutator(name, ret.type)
+
+    if self.level == 0:
+      self.defs.add_alias_or_constant(ret)
+    return ret
+
+  def visit_ClassDef(self, node):
+    class_name = node.name
+    self.defs.type_map[class_name] = pytd.NamedType(class_name)
+
+    # Convert decorators to named types
+    self._preprocess_decorator_list(node)
+    decorators = classdef.get_decorators(
+        node.decorator_list, self.defs.type_map)
+
+    self.annotation_visitor.visit(node.bases)
+    self.annotation_visitor.visit(node.keywords)
+    defs = _flatten_splices(node.body)
+    return self.defs.build_class(
+        class_name, node.bases, node.keywords, decorators, defs)
+
+  def enter_If(self, node):
+    # Evaluate the test and preemptively remove the invalid branch so we don't
+    # waste time traversing it.
+    node.test = conditions.evaluate(node.test, self.version, self.platform)
+    if not isinstance(node.test, bool):
+      raise ParseError("Unexpected if statement" + debug.dump(node, ast3))
+
+    if node.test:
+      node.orelse = []
+    else:
+      node.body = []
+
+  def visit_If(self, node):
+    if not isinstance(node.test, bool):
+      raise ParseError("Unexpected if statement" + debug.dump(node, ast3))
+
+    if node.test:
+      return Splice(node.body)
+    else:
+      return Splice(node.orelse)
+
+  def visit_Import(self, node):
+    if self.level > 0:
+      raise ParseError("Import statements need to be at module level")
+    imports = [_tuple_of_import(x) for x in node.names]
+    self.defs.add_import(None, imports)
+    return Splice([])
+
+  def visit_ImportFrom(self, node):
+    if self.level > 0:
+      raise ParseError("Import statements need to be at module level")
+    imports = [_tuple_of_import(x) for x in node.names]
+    module = _import_from_module(node.module, node.level)
+    self.defs.add_import(module, imports)
+    return Splice([])
+
+  def _convert_newtype_args(self, node):
+    if len(node.args) != 2:
+      msg = "Wrong args: expected NewType(name, [(field, type), ...])"
+      raise ParseError(msg)
+    name, typ = node.args
+    typ = self.convert_node(typ)
+    node.args = [name.s, typ]
+
+  def _convert_typing_namedtuple_args(self, node):
+    # TODO(mdemello): handle NamedTuple("X", a=int, b=str, ...)
+    if len(node.args) != 2:
+      msg = "Wrong args: expected NamedTuple(name, [(field, type), ...])"
+      raise ParseError(msg)
+    name, fields = node.args
+    fields = self.convert_node(fields)
+    fields = [(types.string_value(n), t) for (n, t) in fields]
+    node.args = [name.s, fields]
+
+  def _convert_collections_namedtuple_args(self, node):
+    if len(node.args) != 2:
+      msg = "Wrong args: expected namedtuple(name, [field, ...])"
+      raise ParseError(msg)
+    name, fields = node.args
+    fields = self.convert_node(fields)
+    fields = [(types.string_value(n), pytd.AnythingType()) for n in fields]
+    node.args = [name.s, fields]
+
+  def _convert_typevar_args(self, node):
+    self.annotation_visitor.visit(node.keywords)
+    if not node.args:
+      raise ParseError("Missing arguments to TypeVar")
+    name, *rest = node.args
+    if not isinstance(name, ast3.Str):
+      raise ParseError("Bad arguments to TypeVar")
+    node.args = [name.s] + [self.convert_node(x) for x in rest]
+    # Special-case late types in bound since typeshed uses it.
+    for kw in node.keywords:
+      if kw.arg == "bound":
+        if isinstance(kw.value, types.Constant):
+          val = types.string_value(kw.value, context="TypeVar bound")
+          kw.value = self.annotation_visitor.convert_late_annotation(val)
+
+  def _convert_typed_dict_args(self, node):
+    # TODO(b/157603915): new_typed_dict currently doesn't do anything with the
+    # args, so we don't bother converting them fully.
+    msg = "Wrong args: expected TypedDict(name, {field: type, ...})"
+    if len(node.args) != 2:
+      raise ParseError(msg)
+    name, fields = node.args
+    if not (isinstance(name, ast3.Str) and isinstance(fields, ast3.Dict)):
+      raise ParseError(msg)
+
+  def enter_Call(self, node):
+    # Some function arguments need to be converted from strings to types when
+    # entering the node, rather than bottom-up when they would already have been
+    # converted to types.Constant.
+    # We also convert some literal string nodes that are not meant to be types
+    # (e.g. the first arg to TypeVar()) to their bare values since we are
+    # passing them to internal functions directly in visit_Call.
+    if isinstance(node.func, ast3.Attribute):
+      node.func = _attribute_to_name(node.func)
+    if node.func.id == "TypeVar":
+      self._convert_typevar_args(node)
+    elif node.func.id in ("NamedTuple", "typing.NamedTuple"):
+      self._convert_typing_namedtuple_args(node)
+    elif node.func.id in ("namedtuple", "collections.namedtuple"):
+      self._convert_collections_namedtuple_args(node)
+    elif node.func.id in ("TypedDict", "typing.TypedDict",
+                          "typing_extensions.TypedDict"):
+      self._convert_typed_dict_args(node)
+    elif node.func.id in ("NewType", "typing.NewType"):
+      return self._convert_newtype_args(node)
+
+  def visit_Call(self, node):
+    if node.func.id == "TypeVar":
+      if self.level > 0:
+        raise ParseError("TypeVars need to be defined at module level")
+      return _TypeVar.from_call(node)
+    elif node.func.id in ("NamedTuple", "typing.NamedTuple",
+                          "namedtuple", "collections.namedtuple"):
+      return self.defs.new_named_tuple(*node.args)
+    elif node.func.id in ("TypedDict", "typing.TypedDict",
+                          "typing_extensions.TypedDict"):
+      return self.defs.new_typed_dict(*node.args, total=False)
+    elif node.func.id in ("NewType", "typing.NewType"):
+      return self.defs.new_new_type(*node.args)
+    # Convert all other calls to NamedTypes; for example:
+    # * typing.pyi uses things like
+    #     List = _Alias()
+    # * pytd extensions allow both
+    #     raise Exception
+    #   and
+    #     raise Exception()
+    return pytd.NamedType(node.func.id)
+
+  def visit_Raise(self, node):
+    ret = self.convert_node(node.exc)
+    return types.Raise(ret)
+
+  # Track nesting level
+
+  def enter_FunctionDef(self, node):
+    self.level += 1
+    self.in_function = True
+
+  def leave_FunctionDef(self, node):
+    self.level -= 1
+    self.in_function = False
+
+  def enter_AsyncFunctionDef(self, node):
+    self.enter_FunctionDef(node)
+
+  def leave_AsyncFunctionDef(self, node):
+    self.leave_FunctionDef(node)
+
+  def enter_ClassDef(self, node):
+    self.level += 1
+
+  def leave_ClassDef(self, node):
+    self.level -= 1
+
+
+def post_process_ast(ast, src, name=None):
+  """Post-process the parsed AST."""
+  ast = definitions.finalize_ast(ast)
+  ast = ast.Visit(pep484.ConvertTypingToNative(name))
+
+  if name:
+    ast = ast.Replace(name=name)
+    ast = ast.Visit(visitors.AddNamePrefix())
+  else:
+    # If there's no unique name, hash the sourcecode.
+    ast = ast.Replace(name=hashlib.md5(src.encode("utf-8")).hexdigest())
+  ast = ast.Visit(visitors.StripExternalNamePrefix())
+
+  # Typeshed files that explicitly import and refer to "__builtin__" need to
+  # have that rewritten to builtins
+  return ast.Visit(visitors.RenameBuiltinsPrefix())
+
+
+def _parse(src: str, feature_version: int, filename: str = ""):
+  """Call the typed_ast parser with the appropriate feature version."""
+  try:
+    ast_root_node = ast3.parse(src, filename, feature_version=feature_version)
+  except SyntaxError as e:
+    raise ParseError(e.msg, line=e.lineno, filename=filename) from e
+  return ast_root_node
+
+
+# Python version input type.
+VersionType = Union[int, Tuple[int, ...]]
+
+
+def _feature_version(python_version: VersionType) -> int:
+  """Get the python feature version for the parser."""
+  def from_major(v):
+    # We only use this to set the feature version, and all pyi files need to
+    # parse as at least python 3.6
+    if v == 2:
+      return 6
+    else:
+      # We don't support host python2, so sys.version = 3.x
+      return sys.version_info.minor
+  if isinstance(python_version, int):
+    return from_major(python_version)
+  else:
+    python_version = typing.cast(Tuple[int, ...], python_version)
+    if len(python_version) == 1:
+      return from_major(python_version[0])
+    else:
+      if python_version[0] == 2:
+        return 6
+      return python_version[1]
+
+
+def parse_string(
+    src: str,
+    python_version: VersionType,
+    name: Optional[str] = None,
+    filename: Optional[str] = None,
+    platform: Optional[str] = None
+):
+  return parse_pyi(src, filename=filename, module_name=name,
+                   platform=platform, python_version=python_version)
+
+
+def parse_pyi(
+    src: str,
+    filename: Optional[str],
+    module_name: str,
+    python_version: VersionType,
+    platform: Optional[str] = None
+) -> pytd.TypeDeclUnit:
+  """Parse a pyi string."""
+  filename = filename or ""
+  feature_version = _feature_version(python_version)
+  python_version = utils.normalize_version(python_version)
+  root = _parse(src, feature_version, filename)
+  gen_pytd = GeneratePytdVisitor(
+      src, filename, module_name, python_version, platform)
+  root = gen_pytd.visit(root)
+  root = post_process_ast(root, src, module_name)
+  return root
+
+
+def parse_pyi_debug(
+    src: str,
+    filename: str,
+    module_name: str,
+    python_version: VersionType,
+    platform: Optional[str] = None
+) -> Tuple[pytd.TypeDeclUnit, GeneratePytdVisitor]:
+  """Debug version of parse_pyi."""
+  feature_version = _feature_version(python_version)
+  python_version = utils.normalize_version(python_version)
+  root = _parse(src, feature_version, filename)
+  print(debug.dump(root, ast3, include_attributes=False))
+  gen_pytd = GeneratePytdVisitor(
+      src, filename, module_name, python_version, platform)
+  root = gen_pytd.visit(root)
+  print("---transformed parse tree--------------------")
+  print(root)
+  print("---post-processed---------------------")
+  root = post_process_ast(root, src, module_name)
+  print(root)
+  print("------------------------")
+  print(gen_pytd.defs.type_map)
+  print(gen_pytd.defs.module_path_map)
+  return root, gen_pytd

--- a/pytype/pyi/typed_ast/ast_parser_test.py
+++ b/pytype/pyi/typed_ast/ast_parser_test.py
@@ -1,0 +1,72 @@
+"""Tests for parse_ast.py."""
+
+import sys
+import textwrap
+
+from pytype.pyi.typed_ast import ast_parser
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import pytd
+from pytype.tests import test_base
+
+import unittest
+
+
+class ErrorTest(test_base.UnitTest):
+  """Test parser errors."""
+
+  def test_filename(self):
+    src = textwrap.dedent("""
+      a: int
+      a: int
+    """)
+    with self.assertRaisesRegex(ParseError, "File.*foo.pyi"):
+      ast_parser.parse_pyi(src, "foo.pyi", "foo", (3, 6))
+
+  def test_lineno(self):
+    src = textwrap.dedent("""
+      class A:
+        __slots__ = 0
+    """)
+    with self.assertRaisesRegex(ParseError, "line 3"):
+      ast_parser.parse_pyi(src, "foo.py", "foo", (3, 6))
+
+
+class ConditionTest(test_base.UnitTest):
+  """Test if conditions."""
+
+  def test_basic(self):
+    src = textwrap.dedent("""
+      if sys.version_info[:2] >= (3, 9) and sys.platform == 'linux':
+        a: int
+      elif sys.version_info[0] == 3:
+        a: bool
+      else:
+        a: str
+    """)
+    root = ast_parser.parse_pyi(src, "foo.py", "foo", (3, 6))
+    self.assertCountEqual(root.constants, (
+        pytd.Constant("foo.a", pytd.NamedType("bool")),
+    ))
+
+
+class ParamsTest(test_base.UnitTest):
+  """Test input parameter handling."""
+
+  def test_feature_version(self):
+    cases = [
+        [2, 6],
+        [(2,), 6],
+        [(2, 7), 6],
+        [(2, 7, 8), 6],
+        [3, sys.version_info.minor],
+        [(3,), sys.version_info.minor],
+        [(3, 7), 7],
+        [(3, 8, 2), 8]
+    ]
+    for version, expected in cases:
+      actual = ast_parser._feature_version(version)
+      self.assertEqual(actual, expected)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/pytype/pyi/typed_ast/classdef.py
+++ b/pytype/pyi/typed_ast/classdef.py
@@ -1,0 +1,105 @@
+"""Class definitions in pyi files."""
+
+import collections
+
+from typing import Dict, Optional, List, Tuple
+
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import pytd
+from pytype.pytd.parse import node as pytd_node
+from pytype.pytd.parse import parser_constants  # pylint: disable=g-importing-member
+
+from typed_ast import ast3
+
+
+_TYPED_DICT_ALIASES = (
+    "typing.TypedDict",
+    parser_constants.EXTERNAL_NAME_PREFIX + "typing_extensions.TypedDict")
+
+
+def get_parents(
+    bases: List[ast3.AST]
+) -> Tuple[List[pytd_node.Node], Optional[int]]:
+  """Collect base classes and namedtuple index."""
+
+  parents = []
+  namedtuple_index = None
+  for i, p in enumerate(bases):
+    if _is_parameterized_protocol(p):
+      # From PEP 544: "`Protocol[T, S, ...]` is allowed as a shorthand for
+      # `Protocol, Generic[T, S, ...]`."
+      # https://www.python.org/dev/peps/pep-0544/#generic-protocols
+      parents.append(p.base_type)
+      parents.append(p.Replace(base_type=pytd.NamedType("typing.Generic")))
+    elif isinstance(p, pytd.NamedType) and p.name == "typing.NamedTuple":
+      if namedtuple_index is not None:
+        raise ParseError("cannot inherit from bare NamedTuple more than once")
+      namedtuple_index = i
+      parents.append(p)
+    elif isinstance(p, pytd.Type):
+      parents.append(p)
+    else:
+      msg = "Unexpected class base:" + p
+      raise ParseError(msg)
+
+  return parents, namedtuple_index
+
+
+def get_metaclass(keywords: List[ast3.AST], parents: List[pytd_node.Node]):
+  """Scan keywords for a metaclass."""
+
+  for k in keywords:
+    keyword, value = k.arg, k.value
+    if keyword not in ("metaclass", "total"):
+      raise ParseError("Unexpected classdef kwarg %r" % keyword)
+    elif keyword == "total" and not any(
+        isinstance(parent, pytd.NamedType) and
+        parent.name in _TYPED_DICT_ALIASES for parent in parents):
+      raise ParseError(
+          "'total' allowed as classdef kwarg only for TypedDict subclasses")
+    if keyword == "metaclass":
+      return value
+  return None
+
+
+def get_decorators(decorators: List[str], type_map: Dict[str, pytd_node.Node]):
+  """Process a class decorator list."""
+
+  # Drop the @type_check_only decorator from classes
+  # TODO(mdemello): Workaround for the bug that typing.foo class decorators
+  # don't add the import, since typing.type_check_only is the only one.
+  decorators = [x for x in decorators if x != "type_check_only"]
+
+  # Check for some function/method-only decorators
+  nonclass = {"property", "classmethod", "staticmethod", "overload"}
+  unsupported_decorators = set(decorators) & nonclass
+  if unsupported_decorators:
+    raise ParseError("Unsupported class decorators: %s" % ", ".join(
+        unsupported_decorators))
+
+  # Convert decorators to named types. These are wrapped as aliases because we
+  # otherwise do not allow referencing functions as types.
+  return [pytd.Alias(d, type_map.get(d) or pytd.NamedType(d))
+          for d in decorators]
+
+
+def check_for_duplicate_defs(methods, constants, aliases) -> None:
+  """Check a class's list of definitions for duplicates."""
+  all_names = (list(set(f.name for f in methods)) +
+               [c.name for c in constants] +
+               [a.name for a in aliases])
+  duplicates = [name
+                for name, count in collections.Counter(all_names).items()
+                if count >= 2]
+  if duplicates:
+    raise ParseError(
+        "Duplicate class-level identifier(s): " + ", ".join(duplicates))
+
+
+#------------------------------------------------------
+# pytd utils
+
+
+def _is_parameterized_protocol(t) -> bool:
+  return (isinstance(t, pytd.GenericType) and
+          t.base_type.name == "typing.Protocol")

--- a/pytype/pyi/typed_ast/conditions.py
+++ b/pytype/pyi/typed_ast/conditions.py
@@ -1,0 +1,143 @@
+"""Process conditional blocks in pyi files."""
+
+from typing import Tuple
+
+from pytype import utils
+from pytype.ast import visitor as ast_visitor
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import slots as cmp_slots
+
+from typed_ast import ast3
+
+
+class ConditionEvaluator(ast_visitor.BaseVisitor):
+  """Evaluates if statements in pyi files."""
+
+  def __init__(self, version, platform):
+    super().__init__(ast=ast3)
+    self._compares = {
+        ast3.Eq: cmp_slots.EQ,
+        ast3.Gt: cmp_slots.GT,
+        ast3.Lt: cmp_slots.LT,
+        ast3.GtE: cmp_slots.GE,
+        ast3.LtE: cmp_slots.LE,
+        ast3.NotEq: cmp_slots.NE
+    }
+    self._version = version
+    self._platform = platform
+
+  def _eval_comparison(self, ident, op, value) -> bool:
+    """Evaluate a comparison and return a bool.
+
+    Args:
+      ident: A tuple of a dotted name string and an optional __getitem__ key
+        (int or slice).
+      op: One of the comparison operator strings in cmp_slots.COMPARES.
+      value: Either a string, an integer, or a tuple of integers.
+
+    Returns:
+      The boolean result of the comparison.
+
+    Raises:
+      ParseError: If the comparison cannot be evaluated.
+    """
+    name, key = ident
+    if name == "sys.version_info":
+      if key is None:
+        key = slice(None, None, None)
+      assert isinstance(key, (int, slice))
+      if isinstance(key, int) and not isinstance(value, int):
+        raise ParseError(
+            "an element of sys.version_info must be compared to an integer")
+      if isinstance(key, slice) and not _is_int_tuple(value):
+        raise ParseError(
+            "sys.version_info must be compared to a tuple of integers")
+      try:
+        actual = self._version[key]
+      except IndexError as e:
+        raise ParseError(utils.message(e)) from e
+      if isinstance(key, slice):
+        actual = _three_tuple(actual)
+        value = _three_tuple(value)
+    elif name == "sys.platform":
+      if not isinstance(value, str):
+        raise ParseError("sys.platform must be compared to a string")
+      valid_cmps = (cmp_slots.EQ, cmp_slots.NE)
+      if op not in valid_cmps:
+        raise ParseError(
+            "sys.platform must be compared using %s or %s" % valid_cmps)
+      actual = self._platform
+    else:
+      raise ParseError("Unsupported condition: '%s'." % name)
+    return cmp_slots.COMPARES[op](actual, value)
+
+  def fail(self, name=None):
+    if name:
+      msg = f"Unsupported condition: '{name}'. "
+    else:
+      msg = "Unsupported condition. "
+    msg += "Supported checks are sys.platform and sys.version_info"
+    raise ParseError(msg)
+
+  def visit_Attribute(self, node):
+    if not isinstance(node.value, ast3.Name):
+      self.fail()
+    name = f"{node.value.id}.{node.attr}"
+    if node.value.id != "sys":
+      self.fail(name)
+    return name
+
+  def visit_Slice(self, node):
+    return slice(node.lower, node.upper, node.step)
+
+  def visit_Index(self, node):
+    return node.value
+
+  def visit_Num(self, node):
+    return node.n
+
+  def visit_Str(self, node):
+    return node.s
+
+  def visit_Subscript(self, node):
+    return (node.value, node.slice)
+
+  def visit_Tuple(self, node):
+    return tuple(node.elts)
+
+  def visit_BoolOp(self, node):
+    if isinstance(node.op, ast3.Or):
+      return any(node.values)
+    elif isinstance(node.op, ast3.And):
+      return all(node.values)
+    else:
+      raise ParseError("Unexpected boolean operator: " + node.op)
+
+  def visit_UnaryOp(self, node):
+    if isinstance(node.op, ast3.USub) and isinstance(node.operand, int):
+      return -node.operand
+    else:
+      raise ParseError("Unexpected unary operator: %s" % node.op)
+
+  def visit_Compare(self, node):
+    if isinstance(node.left, tuple):
+      ident = node.left
+    else:
+      ident = (node.left, None)
+    op = self._compares[type(node.ops[0])]
+    right = node.comparators[0]
+    return self._eval_comparison(ident, op, right)
+
+
+def evaluate(test: ast3.AST, version: Tuple[int, int], platform: str) -> bool:
+  return ConditionEvaluator(version, platform).visit(test)
+
+
+def _is_int_tuple(value):
+  """Return whether the value is a tuple of integers."""
+  return isinstance(value, tuple) and all(isinstance(v, int) for v in value)
+
+
+def _three_tuple(value):
+  """Append zeros and slice to normalize the tuple to a three-tuple."""
+  return (value + (0, 0))[:3]

--- a/pytype/pyi/typed_ast/definitions.py
+++ b/pytype/pyi/typed_ast/definitions.py
@@ -1,0 +1,650 @@
+"""Construct and collect pytd definitions to build a TypeDeclUnit."""
+
+import collections
+
+from typing import Any, Dict, List, Optional, Union
+
+import dataclasses
+
+from pytype.pyi.typed_ast import classdef
+from pytype.pyi.typed_ast import function
+from pytype.pyi.typed_ast import namedtuple
+from pytype.pyi.typed_ast import types
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import escape
+from pytype.pytd import pytd
+from pytype.pytd import pytd_utils
+from pytype.pytd import visitors
+from pytype.pytd.parse import node as pytd_node
+from pytype.pytd.parse import parser_constants  # pylint: disable=g-importing-member
+
+from typed_ast import ast3
+
+
+# Typing members that represent sets of types.
+_TYPING_SETS = ("typing.Intersection", "typing.Optional", "typing.Union")
+
+
+def _split_definitions(defs: List[Any]):
+  """Return [constants], [functions] given a mixed list of definitions."""
+  constants = []
+  functions = []
+  aliases = []
+  slots = None
+  classes = []
+  for d in defs:
+    if isinstance(d, pytd.Class):
+      classes.append(d)
+    elif isinstance(d, pytd.Constant):
+      if d.name == "__slots__":
+        pass  # ignore definitions of __slots__ as a type
+      else:
+        constants.append(d)
+    elif isinstance(d, function.NameAndSig):
+      functions.append(d)
+    elif isinstance(d, pytd.Alias):
+      aliases.append(d)
+    elif isinstance(d, types.SlotDecl):
+      if slots is not None:
+        raise ParseError("Duplicate __slots__ declaration")
+      slots = d.slots
+    elif isinstance(d, types.Ellipsis):
+      pass
+    elif isinstance(d, ast3.Expr):
+      raise ParseError("Unexpected expression").at(d)
+    else:
+      msg = "Unexpected definition"
+      lineno = None
+      if isinstance(d, ast3.AST):
+        lineno = getattr(d, "lineno", None)
+      raise ParseError(msg, line=lineno)
+  return constants, functions, aliases, slots, classes
+
+
+def _maybe_resolve_alias(alias, name_to_class, name_to_constant):
+  """Resolve the alias if possible.
+
+  Args:
+    alias: A pytd.Alias
+    name_to_class: A class map used for resolution.
+    name_to_constant: A constant map used for resolution.
+
+  Returns:
+    None, if the alias pointed to an un-aliasable type.
+    The resolved value, if the alias was resolved.
+    The alias, if it was not resolved.
+  """
+  if not isinstance(alias.type, pytd.NamedType):
+    return alias
+  if alias.type.name in _TYPING_SETS:
+    # Filter out aliases to `typing` members that don't appear in typing.pytd
+    # to avoid lookup errors.
+    return None
+  if "." not in alias.type.name:
+    # We'll handle nested classes specially, since they need to be represented
+    # as constants to distinguish them from imports.
+    return alias
+  parts = alias.type.name.split(".")
+  if parts[0] not in name_to_class and parts[0] not in name_to_constant:
+    return alias
+  prev_value = None
+  value = name_to_class.get(parts[0]) or name_to_constant[parts[0]]
+  for part in parts[1:]:
+    prev_value = value
+    # We can immediately return upon encountering an error, as load_pytd will
+    # complain when it can't resolve the alias.
+    if isinstance(value, pytd.Constant):
+      if (not isinstance(value.type, pytd.NamedType) or
+          value.type.name not in name_to_class):
+        # TODO(rechen): Parameterized constants of generic classes should
+        # probably also be allowed.
+        return alias
+      value = name_to_class[value.type.name]
+    if not isinstance(value, pytd.Class):
+      return alias
+    try:
+      value = value.Lookup(part)
+    except KeyError:
+      return alias
+  if isinstance(value, pytd.Class):
+    return pytd.Constant(
+        alias.name, types.pytd_type(pytd.NamedType(alias.type.name)))
+  elif isinstance(value, pytd.Function):
+    # We allow module-level aliases of methods from classes and class instances.
+    # When a static method is aliased, or a normal method is aliased from a
+    # class (not an instance), the entire method signature is copied. Otherwise,
+    # the first parameter ('self' or 'cls') is dropped.
+    new_value = value.Replace(name=alias.name).Replace(kind="method")
+    if value.kind == "staticmethod" or (
+        value.kind == "method" and isinstance(prev_value, pytd.Class)):
+      return new_value
+    return new_value.Replace(signatures=tuple(
+        s.Replace(params=s.params[1:]) for s in new_value.signatures))
+  else:
+    return value.Replace(name=alias.name)
+
+
+class _InsertTypeParameters(visitors.Visitor):
+  """Visitor for inserting TypeParameter instances."""
+
+  def __init__(self, type_params):
+    super().__init__()
+    self.type_params = {p.name: p for p in type_params}
+
+  def VisitNamedType(self, node):
+    if node.name in self.type_params:
+      return self.type_params[node.name]
+    else:
+      return node
+
+
+class _VerifyMutators(visitors.Visitor):
+  """Visitor for verifying TypeParameters used in mutations are in scope."""
+
+  def __init__(self):
+    super().__init__()
+    # A stack of type parameters introduced into the scope. The top of the stack
+    # contains the currently accessible parameter set.
+    self.type_params_in_scope = [set()]
+    self.current_function = None
+
+  def _AddParams(self, params):
+    top = self.type_params_in_scope[-1]
+    self.type_params_in_scope.append(top | params)
+
+  def _GetTypeParameters(self, node):
+    collector = visitors.CollectTypeParameters()
+    node.Visit(collector)
+    return {x.name for x in collector.params}
+
+  def EnterClass(self, node):
+    params = set()
+    for cls in node.parents:
+      params |= self._GetTypeParameters(cls)
+    self._AddParams(params)
+
+  def LeaveClass(self, _):
+    self.type_params_in_scope.pop()
+
+  def EnterFunction(self, node):
+    self.current_function = node
+    params = set()
+    for sig in node.signatures:
+      for arg in sig.params:
+        params |= self._GetTypeParameters(arg.type)
+    self._AddParams(params)
+
+  def LeaveFunction(self, _):
+    self.type_params_in_scope.pop()
+    self.current_function = None
+
+  def EnterParameter(self, node):
+    if isinstance(node.mutated_type, pytd.GenericType):
+      params = self._GetTypeParameters(node.mutated_type)
+      extra = params - self.type_params_in_scope[-1]
+      if extra:
+        fn = pytd_utils.Print(self.current_function)
+        msg = "Type parameter(s) {%s} not in scope in\n\n%s" % (
+            ", ".join(sorted(extra)), fn)
+        raise ParseError(msg)
+
+
+class _ContainsAnyType(visitors.Visitor):
+  """Check if a pytd object contains a type of any of the given names."""
+
+  def __init__(self, type_names):
+    super().__init__()
+    self._type_names = set(type_names)
+    self.found = False
+
+  def EnterNamedType(self, node):
+    if node.name in self._type_names:
+      self.found = True
+
+
+def _contains_any_type(ast, type_names):
+  """Convenience wrapper for _ContainsAnyType."""
+  out = _ContainsAnyType(type_names)
+  ast.Visit(out)
+  return out.found
+
+
+class _PropertyToConstant(visitors.Visitor):
+  """Convert some properties to constant types."""
+
+  def EnterTypeDeclUnit(self, node):
+    self.type_param_names = [x.name for x in node.type_params]
+    self.const_properties = []
+
+  def LeaveTypeDeclUnit(self, node):
+    self.type_param_names = None
+
+  def EnterClass(self, node):
+    self.const_properties.append([])
+
+  def LeaveClass(self, node):
+    self.const_properties.pop()
+
+  def VisitClass(self, node):
+    constants = list(node.constants)
+    for fn in self.const_properties[-1]:
+      ptypes = [x.return_type for x in fn.signatures]
+      constants.append(
+          pytd.Constant(name=fn.name, type=pytd_utils.JoinTypes(ptypes)))
+    methods = [x for x in node.methods if x not in self.const_properties[-1]]
+    return node.Replace(constants=tuple(constants), methods=tuple(methods))
+
+  def EnterFunction(self, node):
+    if (self.const_properties and
+        node.kind == pytd.PROPERTY and
+        not self._is_parametrised(node)):
+      self.const_properties[-1].append(node)
+
+  def _is_parametrised(self, method):
+    for sig in method.signatures:
+      if _contains_any_type(sig.return_type, self.type_param_names):
+        return True
+
+
+class Definitions:
+  """Collect definitions used to build a TypeDeclUnit."""
+
+  ELLIPSIS = types.Ellipsis()  # Object to signal ELLIPSIS as a parameter.
+
+  def __init__(self, module_info):
+    self.module_info = module_info
+    self.type_map: Dict[str, Any] = {}
+    self.constants = []
+    self.aliases = collections.OrderedDict()
+    self.type_params = []
+    self.generated_classes = collections.defaultdict(list)
+    self.module_path_map = {}
+
+  def add_alias_or_constant(self, alias_or_constant):
+    """Add an alias or constant.
+
+    Args:
+      alias_or_constant: the top-level definition to add.
+
+    Raises:
+      ParseError: For an invalid __slots__ declaration.
+    """
+    if isinstance(alias_or_constant, pytd.Constant):
+      self.constants.append(alias_or_constant)
+    elif isinstance(alias_or_constant, types.SlotDecl):
+      raise ParseError("__slots__ only allowed on the class level")
+    elif isinstance(alias_or_constant, pytd.Alias):
+      name, value = alias_or_constant.name, alias_or_constant.type
+      self.type_map[name] = value
+      self.aliases[name] = alias_or_constant
+    else:
+      assert False, "Unknown type of assignment"
+
+  def new_new_type(self, name, typ):
+    """Returns a type for a NewType."""
+    args = [("self", pytd.AnythingType()), ("val", typ)]
+    ret = pytd.NamedType("NoneType")
+    methods = function.merge_method_signatures(
+        [function.NameAndSig.make("__init__", args, ret)])
+    cls_name = escape.pack_newtype_base_class(
+        name, len(self.generated_classes[name]))
+    cls = pytd.Class(name=cls_name,
+                     metaclass=None,
+                     parents=(typ,),
+                     methods=tuple(methods),
+                     constants=(),
+                     decorators=(),
+                     classes=(),
+                     slots=None,
+                     template=())
+    self.generated_classes[name].append(cls)
+    return pytd.NamedType(cls_name)
+
+  def new_named_tuple(self, base_name, fields):
+    """Return a type for a named tuple (implicitly generates a class).
+
+    Args:
+      base_name: The named tuple's name.
+      fields: A list of (name, type) tuples.
+
+    Returns:
+      A NamedType() for the generated class that describes the named tuple.
+    """
+    nt = namedtuple.NamedTuple(base_name, fields, self.generated_classes)
+    self.generated_classes[base_name].append(nt.cls)
+    self.type_params.append(nt.type_param)
+    return pytd.NamedType(nt.name)
+
+  def new_typed_dict(self, name, items, total):
+    """Returns a type for a TypedDict.
+
+    This method is currently called only for TypedDict objects defined via
+    the following function-based syntax:
+
+      Foo = TypedDict('Foo', {'a': int, 'b': str}, total=False)
+
+    rather than the recommended class-based syntax.
+
+    Args:
+      name: the name of the TypedDict instance, e.g., "'Foo'".
+      items: a {key: value_type} dict, e.g., {"'a'": "int", "'b'": "str"}.
+      total: A tuple of a single kwarg, e.g., ("total", NamedType("False")), or
+        None when no kwarg is passed.
+    """
+    # TODO(b/157603915): Add real support for TypedDict.
+    del name, items, total  # unused
+    return pytd.GenericType(
+        pytd.NamedType("typing.Dict"),
+        (pytd.NamedType("str"), pytd.NamedType("typing.Any")))
+
+  def add_type_var(self, name, typevar):
+    """Add a type variable, <name> = TypeVar(<name_arg>, <args>)."""
+    if name != typevar.name:
+      raise ParseError("TypeVar name needs to be %r (not %r)" % (
+          typevar.name, name))
+    bound = typevar.bound
+    if isinstance(bound, str):
+      bound = pytd.NamedType(bound)
+    constraints = tuple(typevar.constraints) if typevar.constraints else ()
+    self.type_params.append(pytd.TypeParameter(
+        name=name, constraints=constraints, bound=bound))
+
+  def add_import(self, from_package, import_list):
+    """Add an import.
+
+    Args:
+      from_package: A dotted package name if this is a "from" statement, or None
+          if it is an "import" statement.
+      import_list: A list of imported items, which are either strings or pairs
+          of strings.  Pairs are used when items are renamed during import
+          using "as".
+    """
+    if from_package:
+      # from a.b.c import d, ...
+      for item in import_list:
+        t = self.module_info.process_from_import(from_package, item)
+        self.type_map[t.new_name] = t.pytd_node
+        if (isinstance(item, tuple) or
+            from_package != "typing" or
+            self.module_info.module_name == "protocols"):
+          self.aliases[t.new_name] = t.pytd_alias()
+          self.module_path_map[t.new_name] = t.qualified_name
+    else:
+      # import a, b as c, ...
+      for item in import_list:
+        t = self.module_info.process_import(item)
+        if t:
+          self.aliases[t.new_name] = t.pytd_alias()
+
+  def _matches_full_name(self, t, full_name):
+    """Whether t.name matches full_name in format {module}.{member}."""
+    expected_module_name, expected_name = full_name.rsplit(".", 1)
+    if self.module_info.module_name == expected_module_name:
+      # full_name is inside the current module, so check for the name without
+      # the module prefix.
+      return t.name == expected_name
+    elif "." not in t.name:
+      # full_name is not inside the current module, so a local type can't match.
+      return False
+    else:
+      module_name, name = t.name.rsplit(".", 1)
+      if module_name in self.aliases:
+        # Adjust the module name if it has been aliased with `import x as y`.
+        # See test_pyi.PYITest.testTypingAlias.
+        module = self.aliases[module_name].type
+        if isinstance(module, pytd.Module):
+          module_name = module.module_name
+      expected_module_names = {
+          expected_module_name,
+          parser_constants.EXTERNAL_NAME_PREFIX + expected_module_name}
+      return module_name in expected_module_names and name == expected_name
+
+  def _is_tuple_base_type(self, t):
+    return isinstance(t, pytd.NamedType) and (
+        t.name == "tuple" or self._matches_full_name(t, "builtins.tuple") or
+        self._matches_full_name(t, "typing.Tuple"))
+
+  def _is_empty_tuple(self, t):
+    return isinstance(t, pytd.TupleType) and not t.parameters
+
+  def _is_heterogeneous_tuple(self, t):
+    return isinstance(t, pytd.TupleType)
+
+  def _is_callable_base_type(self, t):
+    return (isinstance(t, pytd.NamedType) and
+            self._matches_full_name(t, "typing.Callable"))
+
+  def _is_literal_base_type(self, t):
+    return isinstance(t, pytd.NamedType) and (
+        self._matches_full_name(t, "typing.Literal") or
+        self._matches_full_name(t, "typing_extensions.Literal"))
+
+  def _parameterized_type(self, base_type, parameters):
+    """Return a parameterized type."""
+    if self._is_literal_base_type(base_type):
+      return types.pytd_literal(parameters)
+    elif any(isinstance(p, types.Constant) for p in parameters):
+      parameters = ", ".join(
+          p.repr_str() if isinstance(p, types.Constant) else "_"
+          for p in parameters)
+      raise ParseError(
+          "%s[%s] not supported" % (pytd_utils.Print(base_type), parameters))
+    elif types.is_any(base_type):
+      return pytd.AnythingType()
+    elif len(parameters) == 2 and parameters[-1] is self.ELLIPSIS and (
+        not self._is_callable_base_type(base_type)):
+      element_type = parameters[0]
+      if element_type is self.ELLIPSIS:
+        raise ParseError("[..., ...] not supported")
+      return pytd.GenericType(base_type=base_type, parameters=(element_type,))
+    else:
+      parameters = tuple(pytd.AnythingType() if p is self.ELLIPSIS else p
+                         for p in parameters)
+      if self._is_tuple_base_type(base_type):
+        return types.heterogeneous_tuple(base_type, parameters)
+      elif self._is_callable_base_type(base_type):
+        return types.pytd_callable(base_type, parameters)
+      else:
+        assert parameters
+        return pytd.GenericType(base_type=base_type, parameters=parameters)
+
+  def resolve_type(self, name: Union[str, pytd_node.Node]) -> pytd_node.Node:
+    """Return the fully resolved name for an alias.
+
+    Args:
+      name: The name of the type or alias.
+
+    Returns:
+      A pytd.NamedType with the fully resolved and qualified name.
+    """
+    if isinstance(name, (pytd.GenericType, pytd.AnythingType)):
+      return name
+    if isinstance(name, pytd.NamedType):
+      name = name.name
+    if name == "nothing":
+      return pytd.NothingType()
+    base_type = self.type_map.get(name)
+    if base_type is None:
+      module, dot, tail = name.partition(".")
+      full_name = self.module_path_map.get(module, module) + dot + tail
+      base_type = pytd.NamedType(full_name)
+    return base_type
+
+  def new_type(
+      self,
+      name: Union[str, pytd_node.Node],
+      parameters: Optional[List[pytd_node.Node]] = None
+  ) -> pytd_node.Node:
+    """Return the AST for a type.
+
+    Args:
+      name: The name of the type.
+      parameters: List of type parameters.
+
+    Returns:
+      A pytd type node.
+
+    Raises:
+      ParseError: if the wrong number of parameters is supplied for the
+        base_type - e.g., 2 parameters to Optional or no parameters to Union.
+    """
+    base_type = self.resolve_type(name)
+    if not isinstance(base_type, pytd.NamedType):
+      # We assume that all type parameters have been defined. Since pytype
+      # orders type parameters to appear before classes and functions, this
+      # assumption is generally safe. AnyStr is special-cased because imported
+      # type parameters aren't recognized.
+      type_params = self.type_params + [pytd.TypeParameter("typing.AnyStr")]
+      base_type = base_type.Visit(_InsertTypeParameters(type_params))
+      try:
+        resolved_type = visitors.MaybeSubstituteParameters(
+            base_type, parameters)
+      except ValueError as e:
+        raise ParseError(str(e)) from e
+      if resolved_type:
+        return resolved_type
+    if parameters is not None:
+      if (len(parameters) > 1 and isinstance(base_type, pytd.NamedType) and
+          base_type.name == "typing.Optional"):
+        raise ParseError("Too many options to %s" % base_type.name)
+      return self._parameterized_type(base_type, parameters)
+    else:
+      if (isinstance(base_type, pytd.NamedType) and
+          base_type.name in _TYPING_SETS):
+        raise ParseError("Missing options to %s" % base_type.name)
+      return base_type
+
+  def build_class(
+      self, class_name, bases, keywords, decorators, defs
+  ) -> pytd.Class:
+    """Build a pytd.Class from definitions collected from an ast node."""
+    parents, namedtuple_index = classdef.get_parents(bases)
+    metaclass = classdef.get_metaclass(keywords, parents)
+    constants, methods, aliases, slots, classes = _split_definitions(defs)
+
+    # Make sure we don't have duplicate definitions.
+    classdef.check_for_duplicate_defs(methods, constants, aliases)
+
+    # Generate a NamedTuple proxy base class if needed
+    if namedtuple_index is not None:
+      namedtuple_parent = self.new_named_tuple(
+          class_name, [(c.name, c.type) for c in constants])
+      parents[namedtuple_index] = namedtuple_parent
+      constants = []
+
+    if aliases:
+      vals_dict = {val.name: val
+                   for val in constants + aliases + methods + classes}
+      for val in aliases:
+        name = val.name
+        seen_names = set()
+        while isinstance(val, pytd.Alias):
+          if isinstance(val.type, pytd.NamedType):
+            _, _, base_name = val.type.name.rpartition(".")
+            if base_name in seen_names:
+              # This happens in cases like:
+              # class X:
+              #   Y = something.Y
+              # Since we try to resolve aliases immediately, we don't know what
+              # type to fill in when the alias value comes from outside the
+              # class. The best we can do is Any.
+              val = pytd.Constant(name, pytd.AnythingType())
+              continue
+            seen_names.add(base_name)
+            if base_name in vals_dict:
+              val = vals_dict[base_name]
+              continue
+          # The alias value comes from outside the class. The best we can do is
+          # to fill in Any.
+          val = pytd.Constant(name, pytd.AnythingType())
+        if isinstance(val, function.NameAndSig):
+          val = dataclasses.replace(val, name=name)
+          methods.append(val)
+        else:
+          if isinstance(val, pytd.Class):
+            t = types.pytd_type(pytd.NamedType(class_name + "." + val.name))
+          else:
+            t = val.type
+          constants.append(pytd.Constant(name, t))
+
+    parents = [p for p in parents if not isinstance(p, pytd.NothingType)]
+    methods = function.merge_method_signatures(methods)
+    if not parents and class_name not in ["classobj", "object"]:
+      # A parent-less class inherits from classobj in Python 2 and from object
+      # in Python 3. typeshed assumes the Python 3 behavior for all stubs, so we
+      # do the same here.
+      parents = (pytd.NamedType("object"),)
+
+    return pytd.Class(name=class_name, metaclass=metaclass,
+                      parents=tuple(parents),
+                      methods=tuple(methods),
+                      constants=tuple(constants),
+                      classes=tuple(classes),
+                      decorators=tuple(decorators),
+                      slots=slots,
+                      template=())
+
+  def build_type_decl_unit(self, defs) -> pytd.TypeDeclUnit:
+    """Return a pytd.TypeDeclUnit for the given defs (plus parser state)."""
+    # defs contains both constant and function definitions.
+    constants, functions, aliases, slots, classes = _split_definitions(defs)
+    assert not slots  # slots aren't allowed on the module level
+
+    # TODO(mdemello): alias/constant handling is broken in some weird manner.
+    # assert not aliases # We handle top-level aliases in add_alias_or_constant
+    # constants.extend(self.constants)
+
+    if self.module_info.module_name == "builtins":
+      constants.extend(types.builtin_keyword_constants())
+
+    generated_classes = sum(self.generated_classes.values(), [])
+
+    classes = generated_classes + classes
+    functions = function.merge_method_signatures(functions)
+
+    name_to_class = {c.name: c for c in classes}
+    name_to_constant = {c.name: c for c in constants}
+    aliases = []
+    for a in self.aliases.values():
+      t = _maybe_resolve_alias(a, name_to_class, name_to_constant)
+      if t is None:
+        continue
+      elif isinstance(t, pytd.Function):
+        functions.append(t)
+      elif isinstance(t, pytd.Constant):
+        constants.append(t)
+      else:
+        assert isinstance(t, pytd.Alias)
+        aliases.append(t)
+
+    all_names = ([f.name for f in functions] +
+                 [c.name for c in constants] +
+                 [c.name for c in self.type_params] +
+                 [c.name for c in classes] +
+                 [c.name for c in aliases])
+    duplicates = [name
+                  for name, count in collections.Counter(all_names).items()
+                  if count >= 2]
+    if duplicates:
+      raise ParseError(
+          "Duplicate top-level identifier(s): " + ", ".join(duplicates))
+
+    properties = [x for x in functions if x.kind == pytd.PROPERTY]
+    if properties:
+      prop_names = ", ".join(p.name for p in properties)
+      raise ParseError(
+          "Module-level functions with property decorators: " + prop_names)
+
+    return pytd.TypeDeclUnit(name=None,
+                             constants=tuple(constants),
+                             type_params=tuple(self.type_params),
+                             functions=tuple(functions),
+                             classes=tuple(classes),
+                             aliases=tuple(aliases))
+
+
+def finalize_ast(ast: pytd.TypeDeclUnit):
+  ast = ast.Visit(_PropertyToConstant())
+  ast = ast.Visit(_InsertTypeParameters(ast.type_params))
+  ast = ast.Visit(_VerifyMutators())
+  return ast

--- a/pytype/pyi/typed_ast/function.py
+++ b/pytype/pyi/typed_ast/function.py
@@ -1,0 +1,400 @@
+"""Function definitions in pyi files."""
+
+import collections
+import textwrap
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import dataclasses
+
+from pytype import utils
+from pytype.pyi.typed_ast import types
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import pytd
+from pytype.pytd import visitors
+from pytype.pytd.parse import node as pytd_node
+
+from typed_ast import ast3
+
+
+class OverloadedDecoratorError(ParseError):
+  """Inconsistent decorators on an overloaded function."""
+
+  def __init__(self, name, typ, *args, **kwargs):
+    msg = "Overloaded signatures for %s disagree on %sdecorators" % (
+        name, (typ + " " if typ else ""))
+    super().__init__(msg, *args, **kwargs)
+
+
+# Strategies for combining a new decorator with an existing one
+_MERGE, _REPLACE, _DISCARD = 1, 2, 3
+
+
+class Mutator(visitors.Visitor):
+  """Visitor for adding a mutated_type to parameters.
+
+  We model the parameter x in
+    def f(x: old_type):
+      x = new_type
+  as
+    Parameter(name=x, type=old_type, mutated_type=new_type)
+  .
+  This visitor applies the body "x = new_type" to the function signature.
+  """
+
+  def __init__(self, name, new_type):
+    super().__init__()
+    self.name = name
+    self.new_type = new_type
+    self.successful = False
+
+  def VisitParameter(self, p):
+    if p.name == self.name:
+      self.successful = True
+      if p.optional:
+        raise NotImplementedError(
+            "Argument %s can not be both mutable and optional" % p.name)
+      return p.Replace(mutated_type=self.new_type)
+    else:
+      return p
+
+
+@dataclasses.dataclass
+class Param:
+  """Internal representation of function parameters."""
+
+  name: str
+  type: Optional[str] = None
+  default: Any = None
+  kwonly: bool = False
+
+  @classmethod
+  def from_arg(cls, arg: ast3.AST, kwonly=False) -> "Param":
+    """Constructor from an ast.argument node."""
+    p = cls(arg.arg)
+    if arg.annotation:
+      p.type = arg.annotation
+    p.kwonly = kwonly
+    return p
+
+  def to_pytd(self) -> pytd.Parameter:
+    """Return a pytd.Parameter object for a normal argument."""
+    if self.default is not None:
+      default_type = self.default
+      if self.type is None and default_type != pytd.NamedType("NoneType"):
+        self.type = default_type
+    if self.type is None:
+      self.type = pytd.AnythingType()
+
+    optional = self.default is not None
+    return pytd.Parameter(self.name, self.type, self.kwonly, optional, None)
+
+
+@dataclasses.dataclass(frozen=True)
+class NameAndSig:
+  """Internal representation of function signatures."""
+
+  name: str
+  signature: pytd.Signature
+  decorator: Optional[str] = None
+  is_abstract: bool = False
+  is_coroutine: bool = False
+  is_overload: bool = False
+
+  @classmethod
+  def from_function(cls, function: ast3.AST, is_async: bool) -> "NameAndSig":
+    """Constructor from an ast.FunctionDef node."""
+    name = function.name
+
+    # decorators
+    decorators = set(function.decorator_list)
+    abstracts = {"abstractmethod", "abc.abstractmethod"}
+    coroutines = {"coroutine", "asyncio.coroutine", "coroutines.coroutine"}
+    overload = {"overload"}
+    ignored = {"type_check_only"}
+    is_abstract = bool(decorators & abstracts)
+    is_coroutine = bool(decorators & coroutines)
+    is_overload = bool(decorators & overload)
+    decorators -= abstracts
+    decorators -= coroutines
+    decorators -= overload
+    decorators -= ignored
+    # TODO(mdemello): do we need this limitation?
+    if len(decorators) > 1:
+      raise ParseError("Too many decorators for %s" % name)
+    decorator, = decorators if decorators else (None,)
+
+    exceptions = []
+    mutators = []
+    for i, x in enumerate(function.body):
+      if isinstance(x, types.Raise):
+        exceptions.append(x.exception)
+      elif isinstance(x, Mutator):
+        mutators.append(x)
+      elif isinstance(x, types.Ellipsis):
+        pass
+      elif (isinstance(x, ast3.Expr) and
+            isinstance(x.value, ast3.Str) and
+            i == 0):
+        # docstring
+        pass
+      else:
+        msg = textwrap.dedent("""
+            Unexpected statement in function body.
+            Only `raise` statements and type mutations are valid
+        """).lstrip()
+        if isinstance(x, ast3.AST):
+          raise ParseError(msg).at(x)
+        else:
+          raise ParseError(msg)
+
+    # exceptions
+    sig = _pytd_signature(function, is_async, exceptions=exceptions)
+
+    # mutators
+    for mutator in mutators:
+      try:
+        sig = sig.Visit(mutator)
+      except NotImplementedError as e:
+        raise ParseError(utils.message(e)) from e
+      if not mutator.successful:
+        raise ParseError("No parameter named %s" % mutator.name)
+
+    return cls(name, sig, decorator, is_abstract, is_coroutine, is_overload)
+
+  @classmethod
+  def make(
+      cls,
+      name: str,
+      args: List[Tuple[str, pytd_node.Node]],
+      return_type: pytd_node.Node
+  ) -> "NameAndSig":
+    """Make a new NameAndSig from an argument list."""
+    params = tuple(Param(n, t).to_pytd() for (n, t) in args)
+    sig = pytd.Signature(params=params, return_type=return_type,
+                         starargs=None, starstarargs=None,
+                         exceptions=(), template=())
+    return cls(name, sig)
+
+
+def _pytd_signature(
+    function: ast3.AST,
+    is_async: bool,
+    exceptions: Optional[List[pytd_node.Node]] = None
+) -> pytd.Signature:
+  """Construct a pytd signature from an ast.FunctionDef node."""
+  name = function.name
+  args = function.args
+  pos_params = [Param.from_arg(a, False) for a in args.args]
+  kwonly_params = [Param.from_arg(a, True) for a in args.kwonlyargs]
+  _apply_defaults(pos_params, args.defaults)
+  _apply_defaults(kwonly_params, args.kw_defaults)
+  all_params = pos_params + kwonly_params
+  params = tuple([x.to_pytd() for x in all_params])
+  starargs = _pytd_star_param(args.vararg)
+  starstarargs = _pytd_starstar_param(args.kwarg)
+  ret = _pytd_return_type(name, function.returns, is_async)
+  exceptions = exceptions or []
+  return pytd.Signature(params=params,
+                        return_type=ret,
+                        starargs=starargs,
+                        starstarargs=starstarargs,
+                        exceptions=tuple(exceptions), template=())
+
+
+def _pytd_return_type(
+    name: str,
+    return_type: Optional[pytd_node.Node],
+    is_async: bool
+) -> pytd_node.Node:
+  """Convert function return type to pytd."""
+  if name == "__init__":
+    if (return_type is None or
+        isinstance(return_type, pytd.AnythingType)):
+      ret = pytd.NamedType("NoneType")
+    else:
+      ret = return_type
+  elif is_async:
+    base = pytd.NamedType("typing.Coroutine")
+    params = (pytd.AnythingType(), pytd.AnythingType(), return_type)
+    ret = pytd.GenericType(base, params)
+  elif return_type is None:
+    ret = pytd.AnythingType()
+  else:
+    ret = return_type
+  return ret
+
+
+def pytd_default_star_param() -> pytd.Parameter:
+  return pytd.Parameter("args", pytd.NamedType("tuple"), False, True, None)
+
+
+def pytd_default_starstar_param() -> pytd.Parameter:
+  return pytd.Parameter("kwargs", pytd.NamedType("dict"), False, True, None)
+
+
+def _pytd_star_param(arg: ast3.AST) -> Optional[pytd.Parameter]:
+  """Return a pytd.Parameter for a *args argument."""
+  if not arg:
+    return None
+  name = arg.arg
+  if arg.annotation is None:
+    param_type = pytd.NamedType("tuple")
+  else:
+    param_type = pytd.GenericType(
+        pytd.NamedType("tuple"), (arg.annotation,))
+  return pytd.Parameter(name, param_type, False, True, None)
+
+
+def _pytd_starstar_param(arg: ast3.AST) -> Optional[pytd.Parameter]:
+  """Return a pytd.Parameter for a **kwargs argument."""
+  if not arg:
+    return None
+  name = arg.arg
+  if arg.annotation is None:
+    param_type = pytd.NamedType("dict")
+  else:
+    param_type = pytd.GenericType(
+        pytd.NamedType("dict"), (pytd.NamedType("str"),
+                                 arg.annotation))
+  return pytd.Parameter(name, param_type, False, True, None)
+
+
+def _apply_defaults(params: List[Param], defaults: List[Any]) -> None:
+  for p, d in zip(reversed(params), reversed(defaults)):
+    if d is None:
+      continue
+    elif isinstance(d, types.Constant):
+      p.default = d.to_pytd()
+    else:
+      p.default = pytd.AnythingType()
+
+
+def merge_method_signatures(
+    signatures: List[NameAndSig]
+) -> List[pytd.Function]:
+  """Group the signatures by name, turning each group into a function."""
+  name_to_signatures = collections.OrderedDict()
+  name_to_decorator = {}
+  name_to_is_abstract = {}
+  name_to_is_coroutine = {}
+  for sig in signatures:
+    if sig.name not in name_to_signatures:
+      name_to_signatures[sig.name] = []
+      name_to_decorator[sig.name] = sig.decorator
+    old_decorator = name_to_decorator[sig.name]
+    check = _check_decorator_overload(sig.name, old_decorator, sig.decorator)
+    if check == _MERGE:
+      name_to_signatures[sig.name].append(sig.signature)
+    elif check == _REPLACE:
+      name_to_signatures[sig.name] = [sig.signature]
+      name_to_decorator[sig.name] = sig.decorator
+    _add_flag_overload(
+        name_to_is_abstract, sig.name, sig.is_abstract, "abstractmethod")
+    _add_flag_overload(
+        name_to_is_coroutine, sig.name, sig.is_coroutine, "coroutine")
+  methods = []
+  for name, sigs in name_to_signatures.items():
+    decorator = name_to_decorator[name]
+    is_abstract = name_to_is_abstract[name]
+    is_coroutine = name_to_is_coroutine[name]
+    if name == "__new__" or decorator == "staticmethod":
+      kind = pytd.STATICMETHOD
+    elif name == "__init_subclass__" or decorator == "classmethod":
+      kind = pytd.CLASSMETHOD
+    elif _is_property(name, decorator, sigs[0]):
+      kind = pytd.PROPERTY
+      # If we have only setters and/or deleters, replace them with a single
+      # method foo(...) -> Any, so that we infer a constant `foo: Any` even if
+      # the original method signatures are all `foo(...) -> None`. (If we have a
+      # getter we use its return type, but in the absence of a getter we want to
+      # fall back on Any since we cannot say anything about what the setter sets
+      # the type of foo to.)
+      if decorator.endswith(".setter") or decorator.endswith(".deleter"):
+        sigs = [sigs[0].Replace(return_type=pytd.AnythingType())]
+    else:
+      kind = pytd.METHOD
+    flags = 0
+    if is_abstract:
+      flags |= pytd.Function.IS_ABSTRACT
+    if is_coroutine:
+      flags |= pytd.Function.IS_COROUTINE
+    methods.append(pytd.Function(name, tuple(sigs), kind, flags))
+  return methods
+
+
+@dataclasses.dataclass
+class _Property:
+  precedence: int
+  arity: int
+
+
+def _property_decorators(name: str) -> Dict[str, _Property]:
+  """Generates the property decorators for a method name.
+
+  Used internally by other methods.
+
+  Args:
+    name: method name
+
+  Returns:
+    A dictionary of decorators to precedence and required arity
+  """
+  return {
+      "property": _Property(2, 1),
+      (name + ".getter"): _Property(2, 1),
+      (name + ".setter"): _Property(1, 2),
+      (name + ".deleter"): _Property(1, 1)
+  }
+
+
+def _check_decorator_overload(name: str, old: str, new: str) -> int:
+  """Conditions for a decorator to overload an existing one."""
+  properties = _property_decorators(name)
+  if old == new:
+    return _MERGE
+  elif old in properties and new in properties:
+    p_old, p_new = properties[old].precedence, properties[new].precedence
+    if p_old > p_new:
+      return _DISCARD
+    elif p_old == p_new:
+      return _MERGE
+    else:
+      return _REPLACE
+  raise OverloadedDecoratorError(name, "")
+
+
+def _add_flag_overload(
+    mapping: Dict[str, bool], name: str, val: bool, flag: str
+) -> None:
+  if name not in mapping:
+    mapping[name] = val
+  elif mapping[name] != val:
+    raise OverloadedDecoratorError(name, flag)
+
+
+def _is_property(name: str, decorator: str, signature: pytd.Signature) -> bool:
+  """Parse a signature as a property getter, setter, or deleter.
+
+  Checks that the decorator name matches one of {@property, @foo.getter,
+  @foo.setter, @foo.deleter} and that the corresponding signature is valid.
+
+  NOTE: This function assumes that all other recognised decorators have already
+  been handled, and will therefore raise if decorator is not a property.
+
+  Args:
+    name: method name
+    decorator: decorator
+    signature: method signature
+  Returns:
+    True: If we have a valid property decorator
+    False: If decorator is None
+  Raises:
+    ParseError: If we have a non-property decorator.
+  """
+  if not decorator:
+    return False
+  sigs = _property_decorators(name)
+  if decorator in sigs and sigs[decorator].arity == len(signature.params):
+    return True
+  raise ParseError("Unhandled decorator: %s" % decorator)

--- a/pytype/pyi/typed_ast/modules.py
+++ b/pytype/pyi/typed_ast/modules.py
@@ -1,0 +1,117 @@
+"""Handling of module and package related details."""
+
+from typing import Any
+
+import dataclasses
+
+from pytype import file_utils
+from pytype import module_utils
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import pytd
+from pytype.pytd import visitors
+from pytype.pytd.parse import parser_constants  # pylint: disable=g-importing-member
+
+
+@dataclasses.dataclass
+class Import:
+  """Result of processing an import statement."""
+
+  pytd_node: Any
+  name: str
+  new_name: str
+  qualified_name: str = ""
+
+  def pytd_alias(self):
+    return pytd.Alias(self.new_name, self.pytd_node)
+
+
+class Module:
+  """Module and package details."""
+
+  def __init__(self, filename, module_name):
+    self.filename = filename
+    self.module_name = module_name
+    is_package = file_utils.is_pyi_directory_init(filename)
+    self.package_name = module_utils.get_package_name(module_name, is_package)
+    self.parent_name = module_utils.get_package_name(self.package_name, False)
+
+  def _qualify_name_with_special_dir(self, orig_name):
+    """Handle the case of '.' and '..' as package names."""
+    if "__PACKAGE__." in orig_name:
+      # Generated from "from . import foo" - see parser.yy
+      prefix, _, name = orig_name.partition("__PACKAGE__.")
+      if prefix:
+        raise ParseError("Cannot resolve import: %s" % orig_name)
+      return self.package_name + "." + name
+    elif "__PARENT__." in orig_name:
+      # Generated from "from .. import foo" - see parser.yy
+      prefix, _, name = orig_name.partition("__PARENT__.")
+      if prefix:
+        raise ParseError("Cannot resolve import: %s" % orig_name)
+      if not self.parent_name:
+        raise ParseError(
+            "Cannot resolve relative import ..: Package %s has no parent" %
+            self.package_name)
+      return self.parent_name + "." + name
+    else:
+      return None
+
+  def qualify_name(self, orig_name):
+    """Qualify an import name."""
+    # Doing the "builtins" rename here ensures that we catch alias names.
+    orig_name = visitors.RenameBuiltinsPrefixInName(orig_name)
+    if not self.package_name:
+      return orig_name
+    rel_name = self._qualify_name_with_special_dir(orig_name)
+    if rel_name:
+      return rel_name
+    if orig_name.startswith("."):
+      name = module_utils.get_absolute_name(self.package_name, orig_name)
+      if name is None:
+        raise ParseError(
+            "Cannot resolve relative import %s" % orig_name.rsplit(".", 1)[0])
+      return name
+    return orig_name
+
+  def process_import(self, item):
+    """Process 'import a, b as c, ...'."""
+    if not isinstance(item, tuple):
+      # We don't care about imports that are not aliased.
+      return None
+    name, new_name = item
+    module_name = self.qualify_name(name)
+    as_name = self.qualify_name(new_name)
+    t = pytd.Module(name=as_name, module_name=module_name)
+    return Import(pytd_node=t, name=name, new_name=new_name)
+
+  def process_from_import(self, from_package, item):
+    """Process 'from a.b.c import d, ...'."""
+    if isinstance(item, tuple):
+      name, new_name = item
+    else:
+      name = new_name = item
+    qualified_name = self.qualify_name("%s.%s" % (from_package, name))
+    if (from_package in ["__PACKAGE__", "__PARENT__"]
+        and isinstance(item, str)):
+      # This will always be a simple module import (from . cannot import a
+      # NamedType, and without 'as' the name will not be reexported).
+      t = pytd.Module(name=new_name, module_name=qualified_name)
+    else:
+      # We should ideally not need this check, but we have typing
+      # special-cased in some places.
+      if not qualified_name.startswith("typing.") and name != "*":
+        # Mark this as an externally imported type, so that AddNamePrefix
+        # does not prefix it with the current package name.
+        qualified_name = (parser_constants.EXTERNAL_NAME_PREFIX +
+                          qualified_name)
+      t = pytd.NamedType(qualified_name)
+    if name == "*":
+      # A star import is stored as
+      # 'imported_mod.* = imported_mod.*'. The imported module needs to be
+      # in the alias name so that multiple star imports are handled
+      # properly. LookupExternalTypes() replaces the alias with the
+      # contents of the imported module.
+      assert new_name == name
+      new_name = t.name
+    return Import(pytd_node=t, name=name, new_name=new_name,
+                  qualified_name=qualified_name)

--- a/pytype/pyi/typed_ast/namedtuple.py
+++ b/pytype/pyi/typed_ast/namedtuple.py
@@ -1,0 +1,99 @@
+"""Generate pytd classes for named tuples."""
+
+from typing import Any, List, Tuple
+
+from pytype.pyi.typed_ast import function
+from pytype.pyi.typed_ast import types
+from pytype.pytd import escape
+from pytype.pytd import pytd
+
+
+# Attributes that all namedtuple instances have.
+_NAMEDTUPLE_MEMBERS = ("_asdict", "__dict__", "_fields", "__getnewargs__",
+                       "__getstate__", "_make", "_replace")
+
+
+class NamedTuple:
+  """Construct a class for a new named tuple."""
+
+  def __init__(self, base_name, fields, generated_classes):
+    # Handle previously defined NamedTuples with the same name
+    index = len(generated_classes[base_name])
+    self.name = escape.pack_namedtuple_base_class(base_name, index)
+    self.type_param = None  # will be filled in by _new_named_tuple
+    self.cls = self._new_named_tuple(self.name, fields)
+
+  def _new_named_tuple(
+      self,
+      class_name: str,
+      fields: List[Tuple[str, Any]]
+  ) -> pytd.Class:
+    """Generates a pytd class for a named tuple.
+
+    Args:
+      class_name: The name of the generated class
+      fields: A list of (name, type) tuples.
+
+    Returns:
+      A generated class that describes the named tuple.
+    """
+    class_parent = types.heterogeneous_tuple(pytd.NamedType("tuple"),
+                                             tuple(t for _, t in fields))
+    class_constants = tuple(pytd.Constant(n, t) for n, t in fields)
+    # Since the user-defined fields are the only namedtuple attributes commonly
+    # used, we define all the other attributes as Any for simplicity.
+    class_constants += tuple(pytd.Constant(name, pytd.AnythingType())
+                             for name in _NAMEDTUPLE_MEMBERS)
+    methods = function.merge_method_signatures(
+        [self._make_new(class_name, fields), self._make_init()])
+    return pytd.Class(name=class_name,
+                      metaclass=None,
+                      parents=(class_parent,),
+                      methods=tuple(methods),
+                      constants=class_constants,
+                      decorators=(),
+                      classes=(),
+                      slots=tuple(n for n, _ in fields),
+                      template=())
+
+  def _make_new(
+      self,
+      name: str,
+      fields: List[Tuple[str, Any]]
+  ) -> function.NameAndSig:
+    """Build a __new__ method for a namedtuple with the given fields.
+
+    For a namedtuple defined as NamedTuple("_", [("foo", int), ("bar", str)]),
+    generates the method
+      def __new__(cls: Type[_T], foo: int, bar: str) -> _T: ...
+    where _T is a TypeVar bounded by the class type.
+
+    Args:
+      name: The class name.
+      fields: A list of (name, type) pairs representing the namedtuple fields.
+
+    Returns:
+      A function.NameAndSig object for a __new__ method.
+    """
+    type_param = pytd.TypeParameter("_T" + name, bound=pytd.NamedType(name))
+    self.type_param = type_param
+    cls_arg = ("cls", types.pytd_type(type_param))
+    args = [cls_arg] + fields
+    return function.NameAndSig.make("__new__", args, type_param)
+
+  def _make_init(self) -> function.NameAndSig:
+    """Build an __init__ method for a namedtuple.
+
+    Builds a dummy __init__ that accepts any arguments. Needed because our
+    model of builtins.tuple uses __init__.
+
+    Returns:
+      A function.NameAndSig object for an __init__ method.
+    """
+    self_arg = function.Param("self", pytd.AnythingType()).to_pytd()
+    ret = pytd.NamedType("NoneType")
+    sig = pytd.Signature(params=(self_arg,), return_type=ret,
+                         starargs=function.pytd_default_star_param(),
+                         starstarargs=function.pytd_default_starstar_param(),
+                         exceptions=(), template=())
+    return function.NameAndSig("__init__", sig)

--- a/pytype/pyi/typed_ast/parse_ast.py
+++ b/pytype/pyi/typed_ast/parse_ast.py
@@ -1,0 +1,34 @@
+# python3
+
+"""Testing code to run the typed_ast based pyi parser."""
+
+import sys
+
+from pytype import module_utils
+from pytype.pyi import parser
+from pytype.pyi.typed_ast import ast_parser
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+from pytype.pytd import pytd_utils
+
+
+if __name__ == '__main__':
+  filename = sys.argv[1]
+  with open(filename, 'r') as f:
+    src = f.read()
+
+  module_name = module_utils.path_to_module_name(filename)
+
+  version = (3, 6)
+  try:
+    out, _ = ast_parser.parse_pyi_debug(src, filename, module_name, version)
+  except ParseError as e:
+    print(e)
+    sys.exit(1)
+
+  # print out the pytd tree so we can compare it to the output from ast_parser
+  pytd = parser.parse_string(src, filename=filename, python_version=version)
+  print('------pytd--------------')
+  print(pytd)
+
+  print('------round trip--------------')
+  print(pytd_utils.Print(out))

--- a/pytype/pyi/typed_ast/types.py
+++ b/pytype/pyi/typed_ast/types.py
@@ -1,0 +1,263 @@
+"""Common datatypes and pytd utilities."""
+
+from typing import Any, List, Tuple
+
+import dataclasses
+
+from pytype import utils
+from pytype.pytd import pytd
+from pytype.pytd import pytd_utils
+from pytype.pytd.parse import node as pytd_node
+
+from typed_ast import ast3
+
+
+_STRING_TYPES = ("str", "bytes", "unicode")
+
+
+class ParseError(Exception):
+  """Exceptions raised by the parser."""
+
+  def __init__(self, msg, line=None, filename=None, column=None, text=None):
+    super().__init__(msg)
+    self._line = line
+    self._filename = filename
+    self._column = column
+    self._text = text
+
+  def at(self, node, filename=None, src_code=None):
+    """Add position information from `node` if it doesn't already exist."""
+    # NOTE: ast3.Module has no position info, and will be the `node` when
+    # build_type_decl_unit() is called, so we cannot call `node.lineno`
+    if not self._line:
+      self._line = getattr(node, "lineno", None)
+      self._column = getattr(node, "col_offset", None)
+    if not self._filename:
+      self._filename = filename
+    if self._line and src_code:
+      try:
+        self._text = src_code.splitlines()[self._line-1]
+      except IndexError:
+        pass
+    return self
+
+  def clear_position(self):
+    self._line = None
+
+  @property
+  def line(self):
+    return self._line
+
+  def __str__(self):
+    lines = []
+    if self._filename or self._line is not None:
+      lines.append('  File: "%s", line %s' % (self._filename, self._line))
+    if self._column and self._text:
+      indent = 4
+      stripped = self._text.lstrip()
+      lines.append("%*s%s" % (indent, "", stripped))
+      # Output a pointer below the error column, adjusting for stripped spaces.
+      pos = indent + (self._column - 1) - (len(self._text) - len(stripped))
+      lines.append("%*s^" % (pos, ""))
+    lines.append("%s: %s" % (type(self).__name__, utils.message(self)))
+    return "\n".join(lines)
+
+
+# Type aliases
+Parameters = Tuple[pytd_node.Node, ...]
+
+
+class Ellipsis:  # pylint: disable=redefined-builtin
+  pass
+
+
+@dataclasses.dataclass
+class Raise:
+  exception: pytd.NamedType
+
+
+@dataclasses.dataclass
+class SlotDecl:
+  slots: Tuple[str, ...]
+
+
+@dataclasses.dataclass
+class Constant:
+  """Literal constants in pyi files."""
+
+  type: str
+  value: Any
+
+  @classmethod
+  def from_num(cls, node: ast3.Num):
+    if isinstance(node.n, int):
+      return cls("int", node.n)
+    else:
+      return cls("float", node.n)
+
+  @classmethod
+  def from_str(cls, node: ast3.Str):
+    if node.kind == "b":
+      return cls("bytes", node.s)
+    elif node.kind == "u":
+      return cls("unicode", node.s)
+    else:
+      return cls("str", node.s)
+
+  @classmethod
+  def from_const(cls, node: ast3.NameConstant):
+    if node.value is None:
+      return pytd.NamedType("None")
+    return cls(type(node.value).__name__, node.value)
+
+  def to_pytd(self):
+    return pytd.NamedType(self.type)
+
+  def repr_str(self):
+    """String representation with prefixes."""
+    if self.type == "str":
+      val = f"'{self.value}'"
+    elif self.type == "unicode":
+      val = f"u'{self.value}'"
+    elif self.type == "bytes":
+      val = str(self.value)
+    else:
+      # For non-strings
+      val = repr(self.value)
+    return val
+
+  def to_pytd_literal(self):
+    """Make a pytd node from Literal[self.value]."""
+    if self.value is None:
+      return pytd.NamedType("None")
+    if self.type in _STRING_TYPES:
+      val = self.repr_str()
+    else:
+      val = self.value
+    return pytd.Literal(val)
+
+  def negated(self):
+    """Return a new constant with value -self.value."""
+    if self.type in ("int", "float"):
+      return Constant(self.type, -self.value)
+    raise ParseError("Unary `-` can only apply to numeric literals.")
+
+  @classmethod
+  def is_str(cls, value):
+    return isinstance(value, cls) and value.type in _STRING_TYPES
+
+  def __repr__(self):
+    return f"LITERAL({self.repr_str()})"
+
+
+def string_value(val, context=None) -> str:
+  """Convert a Constant(str) to a string if needed."""
+  if isinstance(val, str):
+    return val
+  elif Constant.is_str(val):
+    return str(val.value)
+  else:
+    if context:
+      msg = f"Type mismatch in {context}"
+    else:
+      msg = "Type mismatch"
+    raise ParseError(f"{msg}: Expected str, got {val}")
+
+
+def pytd_list(typ: str) -> pytd_node.Node:
+  if typ:
+    return pytd.GenericType(
+        pytd.NamedType("typing.List"), (pytd.NamedType(typ),))
+  else:
+    return pytd.NamedType("typing.List")
+
+
+def is_any(val) -> bool:
+  if isinstance(val, (pytd.AnythingType, Ellipsis)):
+    return True
+  elif isinstance(val, pytd.NamedType):
+    return val.name == "typing.Any"
+  else:
+    return False
+
+
+def is_none(t) -> bool:
+  return isinstance(t, pytd.NamedType) and t.name in ("None", "NoneType")
+
+
+def heterogeneous_tuple(
+    base_type: pytd.NamedType,
+    parameters: Parameters
+) -> pytd_node.Node:
+  return pytd.TupleType(base_type=base_type, parameters=parameters)
+
+
+def pytd_type(value: pytd_node.Node) -> pytd_node.Node:
+  return pytd.GenericType(pytd.NamedType("type"), (value,))
+
+
+def pytd_literal(parameters: List[Any]) -> pytd_node.Node:
+  """Create a pytd.Literal."""
+  literal_parameters = []
+  for p in parameters:
+    if is_none(p):
+      literal_parameters.append(p)
+    elif isinstance(p, pytd.NamedType):
+      # TODO(b/123775699): support enums.
+      literal_parameters.append(pytd.AnythingType())
+    elif isinstance(p, Constant):
+      literal_parameters.append(p.to_pytd_literal())
+    elif isinstance(p, pytd.Literal):
+      literal_parameters.append(p)
+    elif isinstance(p, pytd.UnionType):
+      for t in p.type_list:
+        if isinstance(t, pytd.Literal):
+          literal_parameters.append(t)
+        else:
+          raise ParseError(f"Literal[{t}] not supported")
+    else:
+      raise ParseError(f"Literal[{p}] not supported")
+  return pytd_utils.JoinTypes(literal_parameters)
+
+
+def pytd_callable(
+    base_type: pytd.NamedType,
+    parameters: Parameters
+) -> pytd_node.Node:
+  """Create a pytd.CallableType."""
+  if isinstance(parameters[0], list):
+    if len(parameters) > 2:
+      raise ParseError(
+          "Expected 2 parameters to Callable, got %d" % len(parameters))
+    if len(parameters) == 1:
+      # We're usually happy to treat omitted parameters as "Any", but we
+      # need a return type for CallableType, or we wouldn't know whether the
+      # last parameter is an argument or return type.
+      parameters += (pytd.AnythingType(),)
+    if not parameters[0] or parameters[0] == [pytd.NothingType()]:
+      # Callable[[], ret] -> pytd.CallableType(ret)
+      parameters = parameters[1:]
+    else:
+      # Callable[[x, ...], ret] -> pytd.CallableType(x, ..., ret)
+      parameters = tuple(parameters[0]) + parameters[1:]
+    return pytd.CallableType(base_type=base_type, parameters=parameters)
+  else:
+    # Fall back to a generic Callable if first param is Any
+    assert parameters
+    if not is_any(parameters[0]):
+      msg = ("First argument to Callable must be a list of argument types "
+             "(got %r)" % parameters[0])
+      raise ParseError(msg)
+    return pytd.GenericType(base_type=base_type, parameters=parameters)
+
+
+def builtin_keyword_constants():
+  # We cannot define these in a pytd file because assigning to a keyword breaks
+  # the python parser.
+  defs = [
+      ("True", "bool"),
+      ("False", "bool"),
+      ("None", "NoneType"),
+      ("__debug__", "bool")
+  ]
+  return [pytd.Constant(name, pytd.NamedType(typ)) for name, typ in defs]

--- a/pytype/pyi/typed_ast/typeshed_parsing_test.py
+++ b/pytype/pyi/typed_ast/typeshed_parsing_test.py
@@ -1,0 +1,104 @@
+"""Test that the typed_ast based parser works identically to the current one."""
+
+import difflib
+import glob
+import sys
+
+from pytype import module_utils
+from pytype.pyi import parser
+from pytype.pyi.typed_ast import ast_parser
+from pytype.pytd import pytd_utils
+
+
+# Diffs that are either inconsequential or a bug in the old parser.
+WONTFIX_BLOCKLIST = frozenset({
+    # namedtuples generated within if-versioned-out code
+    'third_party/py/typeshed/stdlib/2and3/_curses.pyi',
+    'third_party/py/typeshed/stdlib/3/_thread.pyi',
+    'third_party/py/typeshed/stdlib/3/inspect.pyi',
+    'third_party/py/typeshed/stdlib/2and3/time.pyi',
+    'third_party/py/typeshed/stdlib/3/importlib/metadata.pyi',
+    'third_party/py/typeshed/stdlib/3/os/__init__.pyi',
+
+    # outputs defs in the wrong order
+    'third_party/py/typeshed/stdlib/2/urllib2.pyi',
+    'third_party/py/typeshed/stdlib/2/functools.pyi',
+    'third_party/py/typeshed/stdlib/3/json/decoder.pyi',
+    'third_party/py/typeshed/stdlib/3/unittest/mock.pyi',
+    'third_party/py/typeshed/third_party/3/six/__init__.pyi',
+    'third_party/py/typeshed/third_party/2/six/__init__.pyi',
+
+    # " vs ' in Literal
+    'third_party/py/typeshed/stdlib/3/ast.pyi',
+    'third_party/py/typeshed/stdlib/2and3/mailbox.pyi',
+    'third_party/py/typeshed/stdlib/3/tempfile.pyi',
+    'third_party/py/typeshed/stdlib/2and3/aifc.pyi',
+    'third_party/py/typeshed/stdlib/2and3/imaplib.pyi',
+    'third_party/py/typeshed/stdlib/2and3/codecs.pyi',
+    'third_party/py/typeshed/stdlib/2and3/xml/etree/ElementTree.pyi',
+    'third_party/py/typeshed/stdlib/3/multiprocessing/context.pyi',
+    'third_party/py/typeshed/stdlib/3/xmlrpc/client.pyi',
+    'third_party/py/typeshed/stdlib/3/multiprocessing/__init__.pyi',
+    'third_party/py/pytype/stubs/builtins/3/builtins.pytd',
+    'third_party/py/pytype/stubs/builtins/3/__builtin__.pytd',
+
+    # old parser raises an error
+    'third_party/py/typeshed/stdlib/2/typing.pyi',
+    'third_party/py/typeshed/stdlib/3/typing.pyi',
+})
+
+# Diffs that are a bug in the new parser.
+OTHER_BLOCKLIST = frozenset({
+})
+
+BLOCKLIST = WONTFIX_BLOCKLIST | OTHER_BLOCKLIST
+
+
+def test_file(filename):
+  with open(filename, 'r') as f:
+    src = f.read()
+
+  version = sys.version_info[:2]
+
+  # get module name from filename
+  mod = module_utils.path_to_module_name(filename)
+  if mod.startswith('third_party.py.typeshed'):
+    mod = mod.split('.')[5:]
+    mod = '.'.join(mod)
+
+  # Parse using typed ast parser
+  out = ast_parser.parse_pyi(src, filename=filename, module_name=mod,
+                             python_version=version)
+  new = pytd_utils.Print(out).splitlines(True)
+
+  # Parse using bison parser
+  pytd = parser.parse_string(src, name=mod, filename=filename,
+                             python_version=version)
+  old = pytd_utils.Print(pytd).splitlines(True)
+
+  if old != new:
+    print(''.join(old))
+    diff = difflib.unified_diff(old, new, fromfile=filename, tofile=filename)
+    # Display first diff we find and exit.
+    sys.stdout.writelines(diff)
+    print()
+    print(f"FAILED: '{filename}'")
+    sys.exit(1)
+
+
+def test_all(basedir, ext):
+  for f in glob.glob(f'{basedir}/**/*.{ext}', recursive=True):
+    if f in BLOCKLIST:
+      print('SKIPPED:', f)
+      continue
+    print('TESTING:', f)
+    test_file(f)
+
+
+if __name__ == '__main__':
+  if len(sys.argv) > 1:
+    test_file(sys.argv[1])
+  else:
+    test_all('third_party/py/typeshed/stdlib', 'pyi')
+    test_all('third_party/py/typeshed/third_party', 'pyi')
+    test_all('third_party/py/pytype/pytd', 'pytd')

--- a/pytype/pyi/typed_ast/visitor.py
+++ b/pytype/pyi/typed_ast/visitor.py
@@ -1,0 +1,64 @@
+"""Base visitor for typed_ast parse trees."""
+
+from pytype.ast import visitor as ast_visitor
+from pytype.pyi.typed_ast import types
+from pytype.pyi.typed_ast.types import ParseError  # pylint: disable=g-importing-member
+
+from typed_ast import ast3
+
+
+class BaseVisitor(ast_visitor.BaseVisitor):
+  """Base visitor for all typed_ast visitors.
+
+  - Reraises ParseError with position information.
+  - Handles literal constants
+  - Has an optional Definitions member
+  """
+
+  def __init__(self, *, defs=None, filename=None):
+    super().__init__(ast3)
+    self.defs = defs
+    self.filename = filename  # used for error messages
+    self.src_code = None  # set in subclass, used for error messages
+    # Keep track of the name being subscripted. See AnnotationVisitor.visit_Name
+    # for why this is needed.
+    self.subscripted = []
+
+  def _call_visitor(self, node):
+    try:
+      return super()._call_visitor(node)
+    except ParseError as e:
+      raise e.at(node, self.filename, self.src_code)
+
+  def enter(self, node):
+    try:
+      return super().enter(node)
+    except ParseError as e:
+      raise e.at(node, self.filename, self.src_code)
+
+  def leave(self, node):
+    try:
+      return super().leave(node)
+    except ParseError as e:
+      raise e.at(node, self.filename, self.src_code)
+
+  def visit_Ellipsis(self, node):
+    return self.defs.ELLIPSIS
+
+  def visit_NameConstant(self, node):
+    return types.Constant.from_const(node)
+
+  def visit_Num(self, node):
+    return types.Constant.from_num(node)
+
+  def visit_Str(self, node):
+    return types.Constant.from_str(node)
+
+  def visit_Bytes(self, node):
+    return self.visit_Str(node)
+
+  def visit_UnaryOp(self, node):
+    if isinstance(node.op, ast3.USub):
+      if isinstance(node.operand, types.Constant):
+        return node.operand.negated()
+    raise ParseError("Unexpected unary operator: %s" % node.op)

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,5 +68,6 @@ exclude =
     **/*_test.py
     **/test_*.py
     **/*_test_*.py
+    pytype/pyi/typed_ast/
     pytype/tools/merge_pyi/test_data/
     pytype/tools/xref/testdata/


### PR DESCRIPTION
This parser is intended as a drop-in replacement for the current yacc-based
parser. Rather than maintaining our own grammar, it uses the standard typed-ast
library to parse pyi files as python3 code, before converting them to pytype's
internal data structures. This fixes several issues with pytype not parsing
some constructs in typeshed, and should help us track future python syntax
changes a lot more easily.

Since this has several conflicts with the existing parser, it has been
developed internally in a separate branch, and is being merged in as a unit. We
will add detailed documentation of its internals to our developer docs.

PiperOrigin-RevId: 352670366