### PR TITLE
Do a PyPI release of the new pyi parser.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 2021.01.21
+* Switch to a typed_ast-based stub parser.
+* Fix matching of NamedType against LiteralType in --protocols mode.
+* Fix: super() in a list comprehension needs to look at the enclosing frame.
+
 Version 2021.01.14
 * Fix some corner cases with unpacking and function args.
 * Add ImportError attributes name, path for Python 3.3+.

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2021.01.14'
+__version__ = '2021.01.21'


### PR DESCRIPTION
The Build Failures table looks good, so here we go...

PiperOrigin-RevId: 353069312