### PR TITLE
Allow pytype to be installed in Python 3.9.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,13 +20,14 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
 
 
 [options]
 zip_safe = False
-python_requires = >=3.6, <3.9
+python_requires = >=3.6, <3.10
 packages =
     find:
 install_requires =


### PR DESCRIPTION
For https://github.com/google/pytype/issues/749.

I manually ran the pytype tests with host version = 3.9 and target = 3.8
to confirm that, while pytype cannot yet analyze 3.9 code, it has no
trouble running under 3.9.

This change
(1) Ensures that users attempting to install pytype in 3.9 get the
latest version. Currently, they get version 2020.2.6, which is old and a
little broken (see, e.g., https://github.com/google/pytype/issues/834).
(2) Allows users to run pytype in 3.9 and analyze 3.5-3.8 code by
specifying --python_version. This is arguably not very useful, since
pytype won't be able to resolve pip-installed dependencies, but it may
be good enough for small, self-contained projects.

Attempting to run pytype in 3.9 without specifying a lower target version will still produce a 'Python versions > 3.8 are not yet supported' error.