### PR TITLE
Allow callable constants to match protocol methods.

### DIFF
--- a/pytype/abstract.py
+++ b/pytype/abstract.py
@@ -396,6 +396,9 @@ class BaseValue(utils.VirtualMachineWeakrefMixin):
   def isinstance_ClassMethodInstance(self):
     return False  # overridden in special_builtins.ClassMethodInstance
 
+  def isinstance_Function(self):
+    return isinstance(self, Function)
+
   def isinstance_Instance(self):
     return isinstance(self, Instance)
 

--- a/pytype/abstract_utils.py
+++ b/pytype/abstract_utils.py
@@ -745,3 +745,15 @@ def is_var_splat(var):
 
 def unwrap_splat(var):
   return var.data[0].iterable
+
+
+def is_callable(value: _BaseValue):
+  if (value.isinstance_Function() or
+      value.isinstance_ClassMethodInstance() or
+      value.isinstance_StaticMethodInstance()):
+    return True
+  if not value.cls or not value.cls.isinstance_Class():
+    return False
+  _, attr = value.vm.attribute_handler.get_attribute(
+      value.vm.root_node, value.cls, "__call__")
+  return attr is not None

--- a/pytype/matcher.py
+++ b/pytype/matcher.py
@@ -858,9 +858,7 @@ class AbstractMatcher(utils.VirtualMachineWeakrefMixin):
           left_methods.pop(c.name, None)
       elif isinstance(cls, abstract.InterpreterClass):
         for name, member in cls.members.items():
-          if any(isinstance(data, (
-              abstract.Function, special_builtins.ClassMethodInstance,
-              special_builtins.StaticMethodInstance)) for data in member.data):
+          if any(abstract_utils.is_callable(data) for data in member.data):
             left_methods[name] = member
           else:
             left_methods.pop(name, None)

--- a/pytype/tests/py3/test_protocols.py
+++ b/pytype/tests/py3/test_protocols.py
@@ -653,6 +653,24 @@ class ProtocolTest(test_base.TargetPython3BasicTest):
       f(Baz())  # wrong-arg-types
     """)
 
+  def test_decorated_method(self):
+    self.Check("""
+      from typing import Callable
+      from typing_extensions import Protocol
+      class Foo(Protocol):
+        def foo(self):
+          pass
+      def decorate(f: Callable) -> Callable:
+        return f
+      class Bar:
+        @decorate
+        def foo(self):
+          pass
+      def accept(foo: Foo):
+        pass
+      accept(Bar())
+    """)
+
 
 class ProtocolsTestPython3Feature(test_base.TargetPython3FeatureTest):
   """Tests for protocol implementation on a target using a Python 3 feature."""


### PR DESCRIPTION
Previously, pytype only took methods into account for protocol matching. But if
a class has a constant whose type has a `__call__` method, that constant should
be allowed to satisfy a method in a protocol.

Fixes https://github.com/google/pytype/issues/753.

PiperOrigin-RevId: 359181707