### PR TITLE
Allow builtins.tuple to be used for a heterogeneous tuple annotation.

### DIFF
--- a/pytype/tests/py3/test_tuple.py
+++ b/pytype/tests/py3/test_tuple.py
@@ -3,6 +3,7 @@
 from pytype import file_utils
 from pytype.pytd import pytd_utils
 from pytype.tests import test_base
+from pytype.tests import test_utils
 
 
 class TupleTest(test_base.TargetPython3BasicTest):
@@ -215,6 +216,16 @@ class TupleTestPython3Feature(test_base.TargetPython3FeatureTest):
       day: int
       hour: int
       minute: int
+    """)
+
+  @test_utils.skipBeforePy((3, 7), "requires stringified annotations or 3.9+")
+  def test_parameterize_builtins_tuple(self):
+    self.CheckWithErrors("""
+      from __future__ import annotations
+      def f(x: tuple[int, int]):
+        pass
+      f((0,))  # wrong-arg-types
+      f((0, 0))  # ok
     """)
 
 

--- a/pytype/tests/test_errors.py
+++ b/pytype/tests/test_errors.py
@@ -894,13 +894,13 @@ class ErrorTest(test_base.TargetIndependentTest):
 
   def test_bad_annotation(self):
     _, errors = self.InferWithErrors("""
-      tuple[0]  # not-indexable[e1]
+      list[0]  # not-indexable[e1]
       dict[1, 2]  # invalid-annotation[e2]  # invalid-annotation[e3]
       class A(object): pass
       A[3]  # not-indexable[e4]
     """)
     self.assertErrorRegexes(errors, {
-        "e1": r"class tuple", "e2": r"1.*Not a type", "e3": r"2.*Not a type",
+        "e1": r"class list", "e2": r"1.*Not a type", "e3": r"2.*Not a type",
         "e4": r"class A"})
 
   def test_reveal_type(self):

--- a/pytype/tests/test_tuple.py
+++ b/pytype/tests/test_tuple.py
@@ -94,9 +94,9 @@ class TupleTest(test_base.TargetIndependentTest):
   def test_bad_tuple_class_getitem(self):
     _, errors = self.InferWithErrors("""
       v = type((3, ""))
-      w = v[0]  # not-indexable[e]
+      w = v[0]  # invalid-annotation[e]
     """)
-    self.assertErrorRegexes(errors, {"e": r"tuple"})
+    self.assertErrorRegexes(errors, {"e": r"'0'.*Not a type"})
 
   def test_tuple_isinstance(self):
     ty = self.Infer("""


### PR DESCRIPTION
Fixes https://github.com/google/pytype/issues/839.

PiperOrigin-RevId: 359212099