### PR TITLE
Fix dead pyi-examples link in user_guide.md

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -288,7 +288,7 @@ syntax; the one-type-comment-per-parameter syntax isn't supported
 [pep-484-the-typing-module]: https://www.python.org/dev/peps/pep-0484/#the-typing-module
 [pep-526]: https://www.python.org/dev/peps/pep-0526/
 [per-parameter-type-comments-bug]: https://github.com/google/pytype/issues/49
-[pyi-examples]: https://github.com/python/typeshed/tree/master/stdlib/2
+[pyi-examples]: https://github.com/python/typeshed/tree/master/stdlib
 [stdtypes]: https://docs.python.org/2/library/stdtypes.html
 
 <!-- References with different internal and external versions -->


### PR DESCRIPTION
Not sure what the meaning of /2 is, but clicking the link yields GitHub's 404. Removing it points to valid examples to `.pyi` files.