### PR TITLE
Add some minimal support for PEP 612 in type stubs.

### DIFF
--- a/pytype/load_pytd_test.py
+++ b/pytype/load_pytd_test.py
@@ -401,11 +401,12 @@ class ImportPathsTest(test_base.UnitTest):
       loader = load_pytd.Loader(None, self.python_version, pythonpath=[d.path])
       foo = loader.import_name("foo")
       bar = loader.import_name("bar")
-      self.assertEqual(pytd_utils.Print(foo), "foo.List = list")
+      self.assertEqual(pytd_utils.Print(foo),
+                       "from builtins import list as List")
       self.assertEqual(pytd_utils.Print(bar), textwrap.dedent("""
         from typing import List
 
-        bar.List = list
+        from builtins import list as List
 
         def bar.f() -> List[int]: ...
       """).strip())
@@ -569,11 +570,7 @@ class PickledPyiLoaderTest(test_base.UnitTest):
       self._pickle_modules(loader, d, foo, bar)
       loaded_ast = self._load_pickled_module(d, bar)
       loaded_ast.Visit(visitors.VerifyLookup())
-      self.assertMultiLineEqual(pytd_utils.Print(loaded_ast),
-                                textwrap.dedent("""
-        import foo
-
-        bar.A = foo.A""").lstrip())
+      self.assertEqual(pytd_utils.Print(loaded_ast), "from foo import A")
 
   def test_function_alias(self):
     with file_utils.Tempdir() as d:

--- a/pytype/pytd/printer.py
+++ b/pytype/pytd/printer.py
@@ -152,13 +152,16 @@ class PrintVisitor(base_visitor.Visitor):
 
   def VisitAlias(self, node):
     """Convert an import or alias to a string."""
-    if isinstance(self.old_node.type, pytd.NamedType):
+    if isinstance(self.old_node.type, (pytd.NamedType, pytd.ClassType)):
       full_name = self.old_node.type.name
       suffix = ""
       module, _, name = full_name.rpartition(".")
       if module:
-        if name not in ("*", self.old_node.name):
-          suffix += " as " + self.old_node.name
+        alias_name = self.old_node.name
+        if alias_name.startswith(f"{self._unit_name}."):
+          alias_name = alias_name[len(self._unit_name)+1:]
+        if name not in ("*", alias_name):
+          suffix += " as " + alias_name
         self.imports = self.old_imports  # undo unnecessary imports change
         return "from " + module + " import " + name + suffix
     elif isinstance(self.old_node.type, (pytd.Constant, pytd.Function)):

--- a/pytype/pytd/visitors_test.py
+++ b/pytype/pytd/visitors_test.py
@@ -288,11 +288,7 @@ class TestVisitors(parser_test_base.ParserTest):
     ast2 = ast2.Visit(visitors.LookupExternalTypes(
         {"foo": ast1}, self_name=None))
     self.assertEqual(name, ast2.name)
-    self.assertMultiLineEqual(pytd_utils.Print(ast2), textwrap.dedent("""
-      import foo
-
-      A = foo.A
-    """).strip())
+    self.assertEqual(pytd_utils.Print(ast2), "from foo import A")
 
   def test_lookup_two_star_aliases(self):
     src1 = "class A: ..."


### PR DESCRIPTION
pytype will gracefully fall back to Any when typing.ParamSpec or
typing.Concatenate is used as the first argument to a Callable in a type stub,
allowing typeshed to start using most of PEP 612. Custom generic classes
parameterized with a ParamSpec are still not supported.

pytype was reporting weird [bad-unpacking] errors in parser.py, so I kept
adding ast3.AST annotations until they went away.

I also fixed a bug in PrintVisitor that caused it to print typing_extensions
imports as aliases rather than imports.

For https://github.com/google/pytype/issues/786.

PiperOrigin-RevId: 366342708