### PR TITLE
Disable lint warning consider-using-with.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -22,6 +22,7 @@ disable=
   consider-using-enumerate,
   consider-using-in,
   consider-using-ternary,
+  consider-using-with,
   cyclic-import,
   deprecated-method,
   duplicate-code,


### PR DESCRIPTION
This warning seems useful, so I may reenable it later, but the changes
needed to satisfy it are not obviously safe, so disabling for now.