### PR TITLE
Do some cleanup/refactoring to prepare for a generics bug fix.

### DIFF
--- a/pytype/abstract_utils.py
+++ b/pytype/abstract_utils.py
@@ -667,14 +667,8 @@ class Local:
     self.vm = vm
 
   @property
-  def last_op(self):
-    # TODO(b/74434237): This property can be removed once the usage of it in
-    # dataclass_overlay is gone.
-    return self._ops[-1]
-
-  @property
   def stack(self):
-    return self.vm.simple_stack(self.last_op)
+    return self.vm.simple_stack(self._ops[-1])
 
   def update(self, node, op, typ, orig):
     """Update this variable's annotation and/or value."""

--- a/pytype/function.py
+++ b/pytype/function.py
@@ -283,6 +283,9 @@ class Signature:
     return "def {name}({args}) -> {ret}".format(
         name=self.name, args=args, ret=ret if ret else "Any")
 
+  def get_first_arg(self, callargs):
+    return callargs.get(self.param_names[0]) if self.param_names else None
+
 
 class Args(collections.namedtuple(
     "Args", ["posargs", "namedargs", "starargs", "starstarargs"])):

--- a/pytype/overlays/attr_overlay.py
+++ b/pytype/overlays/attr_overlay.py
@@ -75,7 +75,7 @@ class Attrs(classgen.Decorator):
               init=attrib.init,
               kw_only=attrib.kw_only,
               default=attrib.default)
-          cls.members[name] = classgen.instantiate(node, name, attr.typ)
+          classgen.add_member(node, cls, name, attr.typ)
         else:
           # cls.members[name] has already been set via a typecomment
           attr = Attribute(
@@ -95,7 +95,7 @@ class Attrs(classgen.Decorator):
           attr = Attribute(
               name=name, typ=typ, init=True, kw_only=False, default=orig)
           if not orig:
-            cls.members[name] = classgen.instantiate(node, name, typ)
+            classgen.add_member(node, cls, name, typ)
           own_attrs.append(attr)
 
     cls.record_attr_ordering(own_attrs)

--- a/pytype/overlays/classgen.py
+++ b/pytype/overlays/classgen.py
@@ -187,11 +187,11 @@ def is_dunder(name):
   return name.startswith("__") and name.endswith("__")
 
 
-def instantiate(node, name, typ):
+def add_member(node, cls, name, typ):
   # See test_attr.TestAttrib.test_repeated_default - keying on the name prevents
   # attributes from sharing the same default object.
   _, instance = typ.vm.init_class(node, typ, extra_key=name)
-  return instance
+  cls.members[name] = instance
 
 
 def get_class_locals(cls_name, allow_methods, ordering, vm):

--- a/pytype/overlays/dataclass_overlay.py
+++ b/pytype/overlays/dataclass_overlay.py
@@ -47,7 +47,7 @@ class Dataclass(classgen.Decorator):
       # annotation as InitVar[...].
       del self.vm.annotated_locals[cls.name][name]
     else:
-      cls.members[name] = classgen.instantiate(node, name, initvar)
+      classgen.add_member(node, cls, name, initvar)
     return initvar
 
   def get_class_locals(self, node, cls):
@@ -81,7 +81,7 @@ class Dataclass(classgen.Decorator):
         kind = classgen.AttributeKinds.INITVAR
       else:
         if not orig:
-          cls.members[name] = classgen.instantiate(node, name, typ)
+          classgen.add_member(node, cls, name, typ)
         if is_field(orig):
           field = orig.data[0]
           orig = field.default

--- a/pytype/state.py
+++ b/pytype/state.py
@@ -2,6 +2,7 @@
 
 import collections
 import logging
+from typing import Collection, Optional
 
 from pytype import abstract
 from pytype import class_mixin
@@ -233,7 +234,8 @@ class Frame(utils.VirtualMachineWeakrefMixin):
   """
 
   def __init__(self, node, vm, f_code, f_globals, f_locals, f_back, callargs,
-               closure, func, first_arg=None):
+               closure, func, first_arg: Optional[cfg.Variable],
+               type_params: Collection[abstract.TypeParameter]):
     """Initialize a special frame as needed by TypegraphVirtualMachine.
 
     Args:
@@ -247,7 +249,8 @@ class Frame(utils.VirtualMachineWeakrefMixin):
       callargs: Additional function arguments to store in f_locals.
       closure: A tuple containing the new co_freevars.
       func: An Optional[cfg.Binding] to the function this frame corresponds to.
-      first_arg: Optional first argument to the function.
+      first_arg: First argument to the function.
+      type_params: Type parameters in scope for this frame.
     Raises:
       NameError: If we can't resolve any references into the outer frame.
     """
@@ -320,6 +323,7 @@ class Frame(utils.VirtualMachineWeakrefMixin):
         i = f_code.co_cellvars.index(closure_name)
         self.class_closure_var = self.cells[i]
     self.func = func
+    self.type_params = type_params
 
   def __repr__(self):     # pragma: no cover
     return "<Frame at 0x%08x: %r @ %d>" % (


### PR DESCRIPTION
I'm trying to add support to pytype for annotating a class's attributes with
TypeVars that the class is generic in, which should also partially fix the
generic containers bug. As usual, the change got much too large, so this is the
part of it that shouldn't have any user-visible effect.

* Pulls out various pieces of code in abstract.py into their own methods, so
  they can be later extended and/or reused.
* Moves InterpreterFunction._mutations_generator into the SignedFunction base
  class, so it can also be used in SimpleFunction. (Amazingly,
  _mutations_generator works with no changes on SimpleFunctions!)
* Replaces the is_var argument to extract_annotation() with
  allowed_type_params, which tells pytype what type parameters are in scope and
  are allowed to be used in annotations. allowed_type_params come from two
  sources: apply_annotation() (which currently just passes in ()) and a new
  type_params field in VM frames (which is also currently always empty).
* Gets rid of an unused @property in abstract_utils.
* Replaces classgen.instantiate() with classgen.add_member(), which takes and
  manipulates the class rather than returning a member that the calling code
  adds to the class. This is so I can add special logic for type parameters.

PiperOrigin-RevId: 373893819