### PR TITLE
Add support for PEP 604 (Union |) in stub files

### DIFF
--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -190,6 +190,12 @@ class AnnotationVisitor(visitor.BaseVisitor):
     annotation = _attribute_to_name(node).id
     return self.defs.new_type(annotation)
 
+  def visit_BinOp(self, node):
+    if isinstance(node.op, ast3.BitOr):
+      return self.defs.new_type("typing.Union", [node.left, node.right])
+    else:
+      raise ParseError(f"Unexpected operator {node.op}")
+
   def visit_BoolOp(self, node):
     if isinstance(node.op, ast3.Or):
       raise ParseError("Deprecated syntax `x or y`; use `Union[x, y]` instead")

--- a/pytype/pyi/parser_test.py
+++ b/pytype/pyi/parser_test.py
@@ -2925,6 +2925,21 @@ class ConcatenateTest(_ParserTestBase):
     """)
 
 
+class UnionOrTest(_ParserTestBase):
+  def test(self):
+    self.check("""
+      def f(x: int | str) -> None: ...
+      def g(x: bool | str | float) -> None: ...
+      def h(x: str | None) -> None: ...
+    """, """
+      from typing import Optional, Union
+
+      def f(x: Union[int, str]) -> None: ...
+      def g(x: Union[bool, str, float]) -> None: ...
+      def h(x: Optional[str]) -> None: ...
+    """)
+
+
 class TypeGuardTest(_ParserTestBase):
 
   def test_typing_extensions(self):


### PR DESCRIPTION
Part of #785, though not a complete fix because this doesn't allow the `|` syntax at runtime (I think).

I was pleasantly surprised by how easy this change was. I hope that doesn't mean I missed something.