### PR TITLE
Add an initial copybara config for pytype_extensions.

### DIFF
--- a/pytype_extensions/LICENSE
+++ b/pytype_extensions/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Google LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pytype_extensions/README.md
+++ b/pytype_extensions/README.md
@@ -1,0 +1,2 @@
+"pytype_extensions" contains type system extensions for use with the
+[pytype type analyzer](https://google.github.io/pytype/).

--- a/pytype_extensions/__init__.py
+++ b/pytype_extensions/__init__.py
@@ -1,0 +1,65 @@
+# Lint as: python2, python3
+"""Type system extensions for use with pytype."""
+from __future__ import google_type_annotations
+
+import typing
+from typing import Text, Dict, Any, TypeVar, Callable
+
+
+if typing.TYPE_CHECKING:
+
+  _GenericCallable = TypeVar('_GenericCallable', bound=Callable[..., Any])
+
+  class Decorator(object):
+    """A type annotation for decorators that do not change signatures.
+
+    This is a stand-in for using `Callable[[T], T]` to represent a decorator.
+
+    Given a decorator function, which takes in a callable and returns a callable
+    with the same signature, apply this class as a decorator to that function.
+    This can also be used for decorator factories.
+
+    Examples:
+
+    Plain decorator (decorator matches Callable[[T], T]):
+
+    >>> @pytype_extensions.Decorator
+    ... def MyDecorator(func):
+    ...   def wrapper(...):
+    ...     ...
+    ...   return wrapper
+
+    Decorator factory (factory matches Callable[..., Callable[[T], T]]):
+
+    >>> def MyDecoratorFactory(foo: int) -> pytype_extensions.Decorator:
+    ...   @pytype_extensions.Decorator
+    ...   def MyDecorator(func):
+    ...     def Wrapper(*args, **kwargs):
+    ...       return func(foo, *args, **kwargs)
+    ...     return Wrapper
+    ...   return MyDecorator
+
+    Note for the above example: the return type annotation (first line) is the
+    most important one; it indicates to callers that MyDecoratorFactory is
+    returning a decorator. The "@pytype_extensions.Decorator" annotation (second
+    line) indicates to pytype that MyDecorator is a Decorator; without it, you
+    would need to add "pytype: disable=bad-return-type" on the final line.
+
+    This class only exists at build time, for typechecking. At runtime, the
+    'Decorator' member of this module is a simple identity function (see below).
+
+    More information: pytype-decorators
+
+    Shortlink: pytype_extensions.Decorator
+    """
+    # pylint: disable=pointless-statement, line-too-long, unused-argument
+
+    def __init__(self, decorator: Callable[[_GenericCallable], _GenericCallable]):
+      ...
+
+    def __call__(self, func: _GenericCallable) -> _GenericCallable:
+      ...  # pytype: disable=bad-return-type
+
+else:
+  # At runtime, Decorator is a simple identify function that returns its input.
+  Decorator = lambda d: d

--- a/pytype_extensions/test_pytype_extensions.py
+++ b/pytype_extensions/test_pytype_extensions.py
@@ -1,0 +1,103 @@
+# Lint as: python2, python3
+"""Tests for pytype_extensions."""
+
+from __future__ import google_type_annotations
+
+import os
+from typing import Text
+
+from pytype import errors
+from pytype import file_utils
+from pytype.pytd import pytd_utils
+from pytype.tests import test_base
+
+
+def InitContents():
+  with open(os.path.join(os.path.dirname(__file__), '__init__.py'), 'r') as f:
+    lines = f.readlines()
+  # Remove the 'google_type_annotations' import, because tests will re-add it.
+  lines.remove('from __future__ import google_type_annotations\n')
+  return ''.join(lines)
+
+
+class CodeTest(test_base.TargetIndependentTest):
+
+  def CheckWithErrors(self, code: Text) -> errors.ErrorLog:
+    extensions_pyi = pytd_utils.Print(self.Infer(InitContents()))
+    with file_utils.Tempdir() as d:
+      d.create_file('pytype_extensions.pyi', extensions_pyi)
+      return super(CodeTest, self).CheckWithErrors(code, pythonpath=[d.path])
+
+
+class DecoratorTest(CodeTest):
+  """Tests for pytype_extensions.Decorator."""
+
+  def testPlainDecorator(self):
+    errorlog = self.CheckWithErrors("""
+        import pytype_extensions
+
+        @pytype_extensions.Decorator
+        def MyDecorator(f):
+          def wrapper(*a, **kw):
+            return f(*a, **kw)
+          return wrapper
+
+
+        class MyClz(object):
+
+          @MyDecorator
+          def DecoratedMethod(self, i: int) -> float:
+            reveal_type(self)  # reveal-type[e1]
+            return i / 2
+
+          def PytypeTesting(self):
+            reveal_type(self.DecoratedMethod)  # reveal-type[e2]
+            reveal_type(self.DecoratedMethod(1))  # reveal-type[e3]
+
+
+        reveal_type(MyClz.DecoratedMethod)  # reveal-type[e4]
+    """)
+    self.assertErrorRegexes(errorlog, {
+        'e1': r'MyClz', 'e2': r'.*Callable\[\[int\], float\].*', 'e3': r'float',
+        'e4': r'Callable\[\[Any, int\], float\]'})
+
+  def testDecoratorFactory(self):
+    errorlog = self.CheckWithErrors("""
+        import pytype_extensions
+
+
+        def MyDecoratorFactory(level: int):
+          @pytype_extensions.Decorator
+          def decorator(f):
+            def wrapper(*a, **kw):
+              return f(*a, **kw)
+            return wrapper
+          return decorator
+
+
+        class MyClz(object):
+
+          @MyDecoratorFactory('should be int')  # wrong-arg-types[e1]
+          def MisDecoratedMethod(self) -> int:
+            return 'bad-return-type'  # bad-return-type[e2]
+
+          @MyDecoratorFactory(123)
+          def FactoryDecoratedMethod(self, i: int) -> float:
+            reveal_type(self)  # reveal-type[e3]
+            return i / 2
+
+          def PytypeTesting(self):
+            reveal_type(self.FactoryDecoratedMethod)  # reveal-type[e4]
+            reveal_type(self.FactoryDecoratedMethod(1))  # reveal-type[e5]
+
+
+        reveal_type(MyClz.FactoryDecoratedMethod)  # reveal-type[e6]
+    """)
+    self.assertErrorRegexes(errorlog, {
+        'e1': r'Expected.*int.*Actual.*str',
+        'e2': r'Expected.*int.*Actual.*str', 'e3': r'MyClz',
+        'e4': r'.*Callable\[\[int\], float\].*', 'e5': r'float',
+        'e6': r'Callable\[\[Any, int\], float\]'})
+
+
+test_base.main(globals(), __name__ == '__main__')


### PR DESCRIPTION
This exports pytype_extensions as a new directory in the pytype GitHub repo.

The config is branched from pytype/copy.bara.sky.

PiperOrigin-RevId: 377313194