### PR TITLE
pytype_extensions: remove 'from __future__ import google_type_annotat…

### DIFF
--- a/pytype_extensions/__init__.py
+++ b/pytype_extensions/__init__.py
@@ -1,7 +1,5 @@
 # Lint as: python2, python3
 """Type system extensions for use with pytype."""
-from __future__ import google_type_annotations
-
 import typing
 from typing import Text, Dict, Any, TypeVar, Callable
 

--- a/pytype_extensions/test_pytype_extensions.py
+++ b/pytype_extensions/test_pytype_extensions.py
@@ -1,8 +1,6 @@
 # Lint as: python2, python3
 """Tests for pytype_extensions."""
 
-from __future__ import google_type_annotations
-
 import os
 from typing import Text
 


### PR DESCRIPTION
…ions'.

Seems like there are still a few stragglers using pytype_extensions in py2, so
we can't delete these lines altogether. Instead, I've modified the copybara
config to remove them during export.

PiperOrigin-RevId: 377582188