### PR TITLE
Work with new typeshed structure

### DIFF
--- a/pytype/pytd/typeshed.py
+++ b/pytype/pytd/typeshed.py
@@ -144,9 +144,9 @@ class Typeshed:
     stubs/ contains type information for third-party packages. Each top-level
     directory corresponds to one PyPI package and contains one or more modules,
     plus a metadata file (METADATA.toml). If there are separate Python 2 stubs,
-    they live in an @python2 subdirectory. METADATA.toml
-    takes @python2 into account, so if a package has both foo.pyi and
-    @python2/foo.pyi, METADATA.toml will contain `python2 = True`.
+    they live in an @python2 subdirectory. If stubs support both Python 2 and
+    Python 3 without a separate @python2 directory, METADATA.toml will contain
+    `python2 = True`.
 
     Returns:
       A mapping from module name to a set of
@@ -154,22 +154,31 @@ class Typeshed:
     """
     metadata = {}
     modules = collections.defaultdict(set)
+    py2 = False
+    py3 = False
     for third_party_file in self._list_files("stubs"):
       parts = third_party_file.split(os.path.sep)
       if parts[-1] == "METADATA.toml":  # {package}/METADATA.toml
         _, metadata_file = self._load_file(
             os.path.join("stubs", third_party_file))
         metadata[parts[0]] = toml.loads(metadata_file)
-      elif "@python2" not in parts:  # {package}/{module}
+      elif "@python2" in parts:  # {package}/@python2/{module}
+        py2 = True
+      elif "@python2" not in parts: # {package}/{module}
+        if parts[-1].endswith(".pyi"):
+            py3 = True
         name, _ = os.path.splitext(parts[1])
         modules[parts[0]].add(name)
     packages = collections.defaultdict(set)
     for package, names in modules.items():
       for name in names:
-        # When not specified, packages are Python 3-only
-        if metadata[package].get("python2", False):
+        # When not specified and no @python2 directory exists, packages are
+        # Python 3-only
+        if py2 or metadata[package].get("python2", False):
           packages[name].add((package, 2))
-        if metadata[package].get("python3", True):
+        # When python3 = false or no stubs exist outside @python2, packages
+        # are Python 2-only
+        if py3 and not metadata[package].get("python3", True):
           packages[name].add((package, 3))
     return packages
 

--- a/pytype/pytd/typeshed.py
+++ b/pytype/pytd/typeshed.py
@@ -170,6 +170,8 @@ class Typeshed:
           no_py3_meta.add(parts[0])
       elif "@python2" in parts:  # {package}/@python2/{module}
         py2_dir.add(parts[0])
+        name, _ = os.path.splitext(parts[2])
+        modules[parts[0]].add(name)
       elif "@python2" not in parts:  # {package}/{module}
         if parts[-1].endswith(".pyi"):
           top_level_stubs.add(parts[0])

--- a/pytype/pytd/typeshed.py
+++ b/pytype/pytd/typeshed.py
@@ -166,7 +166,7 @@ class Typeshed:
         py2 = True
       elif "@python2" not in parts: # {package}/{module}
         if parts[-1].endswith(".pyi"):
-            py3 = True
+          py3 = True
         name, _ = os.path.splitext(parts[1])
         modules[parts[0]].add(name)
     packages = collections.defaultdict(set)

--- a/pytype/pytd/typeshed.py
+++ b/pytype/pytd/typeshed.py
@@ -178,7 +178,7 @@ class Typeshed:
           packages[name].add((package, 2))
         # When python3 = false or no stubs exist outside @python2, packages
         # are Python 2-only
-        if py3 and not metadata[package].get("python3", True):
+        if py3 and metadata[package].get("python3", True):
           packages[name].add((package, 3))
     return packages
 


### PR DESCRIPTION
It's now possible that third-party packages have a `@python2` directory and no stubs at top-level. This means they are Python 2-only, even if the corresponding `METADATA.toml` keys are not set.

There are likely more changes in the future.

See python/typeshed#5630 for details.