### PR TITLE
Fix typeshed _load_third_party_packages().

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -59,6 +59,7 @@ disable=
   too-many-return-statements,
   too-many-statements,
   unbalanced-tuple-unpacking,
+  unspecified-encoding,
   unsubscriptable-object,
   unused-argument,
   useless-import-alias,

--- a/pytype/io.py
+++ b/pytype/io.py
@@ -144,7 +144,7 @@ def check_or_generate_pyi(options, loader=None):
     else:
       errorlog, result, ast = generate_pyi(
           src=src, options=options, loader=loader)
-  except utils.UsageError as e:
+  except utils.UsageError:
     raise
   except pyc.CompileError as e:
     errorlog.python_compiler_error(options.input, e.lineno, e.error)

--- a/pytype/io_test.py
+++ b/pytype/io_test.py
@@ -19,8 +19,8 @@ class IOTest(unittest.TestCase):
   """Test IO functions."""
 
   def test_read_source_file_utf8(self):
-    with self._tmpfile(u"abc□def\n") as f:
-      self.assertEqual(io.read_source_file(f.name), u"abc□def\n")
+    with self._tmpfile("abc□def\n") as f:
+      self.assertEqual(io.read_source_file(f.name), "abc□def\n")
 
   @contextlib.contextmanager
   def _tmpfile(self, contents):

--- a/pytype/tools/analyze_project/config_test.py
+++ b/pytype/tools/analyze_project/config_test.py
@@ -41,11 +41,11 @@ class TestBase(unittest.TestCase):
     self.assertFalse(hasattr(conf, 'output'))
     self.assertEqual(conf.pythonpath, [
         path,
-        u'/foo/bar',
-        os.path.join(path, u'baz/quux')
+        '/foo/bar',
+        os.path.join(path, 'baz/quux')
     ])
-    self.assertEqual(conf.python_version, u'2.7')
-    self.assertEqual(conf.disable, u'import-error,module-attr')
+    self.assertEqual(conf.python_version, '2.7')
+    self.assertEqual(conf.disable, 'import-error,module-attr')
 
   def _validate_empty_contents(self, conf):
     for k in config.ITEMS:

--- a/pytype/typegraph/cfg_test.py
+++ b/pytype/typegraph/cfg_test.py
@@ -33,10 +33,10 @@ class CFGTest(unittest.TestCase):
     node = p.NewCFGNode()
     u = p.NewVariable()
     v1 = u.AddBinding(None, source_set=[], where=node)
-    v2 = u.AddBinding(u"data", source_set=[], where=node)
+    v2 = u.AddBinding("data", source_set=[], where=node)
     v3 = u.AddBinding({1: 2}, source_set=[], where=node)
     self.assertIsNone(v1.data)
-    self.assertEqual(v2.data, u"data")
+    self.assertEqual(v2.data, "data")
     self.assertEqual(v3.data, {1: 2})
     self.assertEqual(f"<binding of variable 0 to data {id(v3.data)}>", str(v3))
 


### PR DESCRIPTION
typeshed/tests/pytype_test was still broken for third-party stubs. This turned
out to be because, even ignoring @python2, a package can contain multiple
modules, and a module name can be provided by multiple packages. I also noticed
that typeshed seems to have added a @tests directory; accidentally including it
as a module name doesn't hurt but is technically wrong, so I filtered it out.

PiperOrigin-RevId: 392084509