### PR TITLE
Update typed-ast to 1.5.0, which contains a Python 3.9.8 fix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,10 @@ jobs:
         sudo apt-get install python3.7
 
     - name: Install Dependencies
-      run: pip install -r requirements.txt
+      run: |
+        pip install -r requirements.txt
+        pip install --no-dependencies astroid==2.8.4
+        pip install --no-dependencies pylint==2.11.1
 
     - name: Run Tests
       if: matrix.python-version != '3.10-dev'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,15 @@ importlab>=0.6.1
 libcst
 ninja>=1.10.0.post2
 pybind11>=2.6.0rc3
-pylint
 tabulate
 toml
 typed_ast>=1.5.0
+
+# Astroid and pylint dependencies.
+isort>=4.2.5,<6
+lazy_object_proxy>=1.4.0
+mccabe>=0.6,<0.7
+platformdirs>=2.2.0
+wrapt>=1.11,<1.14
+setuptools>=20.0
+typing-extensions>=3.10;python_version<"3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pybind11>=2.6.0rc3
 pylint
 tabulate
 toml
-typed_ast>=1.4.3
+typed_ast>=1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     ninja>=1.10.0.post2
     tabulate
     toml
-    typed_ast>=1.4.3
+    typed_ast>=1.5.0
 
 [options.packages.find]
 include =

--- a/setup.py
+++ b/setup.py
@@ -27,25 +27,25 @@ from pybind11.setup_helpers import Pybind11Extension  # pylint: disable=g-import
 def get_typegraph_ext():
   """Generates the typegraph extension."""
   return Pybind11Extension(
-    'pytype.typegraph.cfg',
-    sources=[
-      "pytype/typegraph/cfg.cc",
-      "pytype/typegraph/cfg_logging.cc",
-      "pytype/typegraph/pylogging.cc",
-      "pytype/typegraph/reachable.cc",
-      "pytype/typegraph/solver.cc",
-      "pytype/typegraph/typegraph.cc",
-    ],
-    depends=[
-      "pytype/typegraph/cfg_logging.h",
-      "pytype/typegraph/map_util.h",
-      "pytype/typegraph/memory_util.h",
-      "pytype/typegraph/pylogging.h",
-      "pytype/typegraph/reachable.h",
-      "pytype/typegraph/solver.h",
-      "pytype/typegraph/typegraph.h",
-    ],
-    cxx_std=11,
+      'pytype.typegraph.cfg',
+      sources=[
+          "pytype/typegraph/cfg.cc",
+          "pytype/typegraph/cfg_logging.cc",
+          "pytype/typegraph/pylogging.cc",
+          "pytype/typegraph/reachable.cc",
+          "pytype/typegraph/solver.cc",
+          "pytype/typegraph/typegraph.cc",
+      ],
+      depends=[
+          "pytype/typegraph/cfg_logging.h",
+          "pytype/typegraph/map_util.h",
+          "pytype/typegraph/memory_util.h",
+          "pytype/typegraph/pylogging.h",
+          "pytype/typegraph/reachable.h",
+          "pytype/typegraph/solver.h",
+          "pytype/typegraph/typegraph.h",
+      ],
+      cxx_std=11,
   )
 
 def copy_typeshed():


### PR DESCRIPTION
For https://github.com/google/pytype/issues/1044.

See https://github.com/google/pytype/issues/1047 for an explanation of the weirdness going on with astroid/pylint.

I also fixed a lint issue in setup.py that I noticed while playing around with installing various versions of pylint.