### PR TITLE
Only require `typed-ast` for Python < 3.8

### DIFF
--- a/pytype/tools/annotate_ast/main.py
+++ b/pytype/tools/annotate_ast/main.py
@@ -6,7 +6,13 @@ import sys
 from pytype.ast import debug
 from pytype.tools import arg_parser
 from pytype.tools.annotate_ast import annotate_ast
-from typed_ast import ast3
+
+# pylint: disable=g-import-not-at-top
+if sys.version_info >= (3, 8):
+  import ast as ast3
+else:
+  from typed_ast import ast3
+# pylint: enable=g-import-not-at-top
 
 
 def main():

--- a/pytype/tools/xref/indexer.py
+++ b/pytype/tools/xref/indexer.py
@@ -1257,8 +1257,10 @@ def process_file(options, source_text=None, generate_callgraphs=False,
           loader=loader,
           ctx=ctx)
 
+  # pylint: disable=unexpected-keyword-arg
   ast_root_node = ast3.parse(src, options.input,
                              feature_version=options.python_version[1])
+  # pylint: enable=unexpected-keyword-arg
 
   # TODO(mdemello): Get from args
   module_name = "module"

--- a/pytype/tools/xref/indexer.py
+++ b/pytype/tools/xref/indexer.py
@@ -2,6 +2,7 @@
 
 import collections
 import re
+import sys
 from typing import Optional
 
 import attr
@@ -24,7 +25,12 @@ from pytype.tools.xref import callgraph
 from pytype.tools.xref import utils as xref_utils
 from pytype.tools.xref import node_utils
 
-from typed_ast import ast3
+# pylint: disable=g-import-not-at-top
+if sys.version_info >= (3, 8):
+  import ast as ast3
+else:
+  from typed_ast import ast3
+# pylint: enable=g-import-not-at-top
 
 
 # A mapping of offsets between a node's start position and the symbol being

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pybind11>=2.6.0rc3
 pylint
 tabulate
 toml
-typed_ast>=1.5.0
+typed_ast>=1.5.0; python_version < '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     ninja>=1.10.0.post2
     tabulate
     toml
-    typed_ast>=1.5.0
+    typed_ast>=1.5.0; python_version < '3.8'
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Since 2a6a1cebb13a71d5a2dda08ef2e260a81659b392 `pytype` will use the builtin `ast` module instead of `typed-ast` for Python 3.8 or newer. This PR removes the dependency from the requirements files for these newer Python versions.