### PR TITLE
analyze_project: pass feature flags to the INFER command.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 2021.11.29:
+
+Bug fixes:
+* Pass feature flags to the INFER command.
+
 Version 2021.11.24:
 
 New features and updates:

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2021.11.24'
+__version__ = '2021.11.29'

--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -60,6 +60,15 @@ ITEMS = {
 }
 
 
+REPORT_ERRORS_ITEMS = {
+    'disable': Item(
+        None, 'pyi-error', ArgInfo('--disable', ','.join),
+        'Comma or space separated list of error names to ignore.'),
+    'report_errors': Item(
+        None, 'True', ArgInfo('--no-report-errors', lambda v: not v), None),
+}
+
+
 # The missing fields will be filled in by generate_sample_config_or_die.
 def _pytype_single_items():
   """Args to pass through to pytype_single."""
@@ -69,13 +78,7 @@ def _pytype_single_items():
     dest = opt.lstrip('-').replace('-', '_')
     default = str(default)
     out[dest] = Item(None, default, ArgInfo(opt, None), None)
-  out.update({
-      'disable': Item(
-          None, 'pyi-error', ArgInfo('--disable', ','.join),
-          'Comma or space separated list of error names to ignore.'),
-      'report_errors': Item(
-          None, 'True', ArgInfo('--no-report-errors', lambda v: not v), None),
-  })
+  out.update(REPORT_ERRORS_ITEMS)
   return out
 
 

--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -146,9 +146,11 @@ class PytypeRunner:
     self.keep_going = conf.keep_going
     self.jobs = conf.jobs
 
-  def set_custom_options(self, flags_with_values, binary_flags):
+  def set_custom_options(self, flags_with_values, binary_flags, report_errors):
     """Merge self.custom_options into flags_with_values and binary_flags."""
     for dest, value in self.custom_options:
+      if not report_errors and dest in config.REPORT_ERRORS_ITEMS:
+        continue
       arg_info = config.get_pytype_single_item(dest).arg_info
       if arg_info.to_command_line:
         value = arg_info.to_command_line(value)
@@ -174,8 +176,7 @@ class PytypeRunner:
         '--analyze-annotated' if report_errors else '--no-report-errors',
         '--nofail',
     }
-    if report_errors:
-      self.set_custom_options(flags_with_values, binary_flags)
+    self.set_custom_options(flags_with_values, binary_flags, report_errors)
     # Order the flags so that ninja recognizes commands across runs.
     return (
         exe +


### PR DESCRIPTION
Previously, feature flags were passed only to CHECK, so flags that modify
inference behavior didn't work.

Also bumps __version__ and CHANGELOG so I can release this immediately. (No
point in waiting for nightly testing, since we don't use analyze_project
internally anyway.)

For https://github.com/google/pytype/issues/1057.

PiperOrigin-RevId: 412996772