### PR TITLE
Stop excluding pytype/pyi/ files from type-check.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,8 +74,5 @@ exclude =
     **/*_test.py
     **/test_*.py
     **/*_test_*.py
-    pytype/pyi/classdef.py
-    pytype/pyi/function.py
-    pytype/pyi/parser.py
     pytype/tools/merge_pyi/test_data/
     pytype/tools/xref/testdata/


### PR DESCRIPTION
The type errors in these files were fixed a few weeks ago.