### PR TITLE
Move Python 3.10 tests out of experimental and add 3.10 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         platform:
           - manylinux2014_x86_64
           - manylinux2014_aarch64
-        pyver: [cp37-cp37m, cp38-cp38, cp39-cp39]
+        pyver: [cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python_version: [3.7, 3.8, 3.9]
+        python_version: [3.7, 3.8, 3.9, '3.10']
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ['3.7','3.8', '3.9']
+        python-version: ['3.7','3.8', '3.9', '3.10']
         experimental: [false]
         include:
           - os: ubuntu-20.04
-            python-version: '3.10-dev'
+            python-version: '3.11-dev'
             experimental: true
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.8.0
       with:
         access_token: ${{ github.token }}
-    
+
     - uses: actions/checkout@v2
       with:
         submodules: true
@@ -47,9 +47,9 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Run Tests
-      if: matrix.python-version != '3.10-dev'
+      if: matrix.python-version != '3.11-dev'
       run: python build_scripts/ci_script.py
 
-    - name: Run Tests for python 3.10
-      if: matrix.python-version == '3.10-dev'
+    - name: Run Tests for python 3.11
+      if: matrix.python-version == '3.11-dev'
       run: python build_scripts/ci_script.py || exit 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,13 +20,14 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development
 
 
 [options]
 zip_safe = False
-python_requires = >=3.7, <3.10
+python_requires = >=3.7, <3.11
 packages =
     find:
 install_requires =


### PR DESCRIPTION
Python 3.10 has been stable for a while. This PR enables testing against against 3.10 by default and adds support for building wheels on CI.

Fixes #1022

Let's see what CI things 🤞 