### PR TITLE
Unpack ClassVar in constant_to_var so unions are handled correctly.

### DIFF
--- a/pytype/convert.py
+++ b/pytype/convert.py
@@ -403,6 +403,10 @@ class Converter(utils.ContextWeakrefMixin):
       elif (isinstance(pyval, abstract_utils.AsReturnValue) and
             isinstance(cls, pytd.NothingType)):
         return self.no_return.to_variable(node)
+      elif isinstance(cls, pytd.GenericType) and cls.name == "typing.ClassVar":
+        param, = cls.parameters
+        return self.constant_to_var(abstract_utils.AsInstance(param), subst,
+                                    node, source_sets, discard_concrete_values)
       var = self.ctx.program.NewVariable()
       for t in pytd_utils.UnpackUnion(cls):
         if isinstance(t, pytd.TypeParameter):

--- a/pytype/tests/test_typing2.py
+++ b/pytype/tests/test_typing2.py
@@ -720,6 +720,21 @@ class TypingTestPython3Feature(test_base.BaseTest):
         x: ClassVar[int]
     """)
 
+  def test_pyi_classvar_of_union(self):
+    with file_utils.Tempdir() as d:
+      d.create_file("foo.pyi", """
+        from typing import ClassVar, Optional
+        class Foo:
+          x: ClassVar[Optional[str]]
+      """)
+      self.Check("""
+        import foo
+        from typing import Optional
+        def f(x: Optional[str]):
+          pass
+        f(foo.Foo.x)
+      """, pythonpath=[d.path])
+
   def test_ordered_dict(self):
     self.Check("""
       import collections


### PR DESCRIPTION
Fixes https://github.com/google/pytype/issues/1138.

PiperOrigin-RevId: 431027196