### PR TITLE
Clean up pytype install requirements and documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ dependencies.
    and active, you can skip installing the official ninja distribution.
 6. __Python3.x Interpreter__: You will need to install an interpreter for a
    Python version that pytype can run under (see [Requirements](README.md#requirements)).
+   Make sure you also install the developer package (often named python3.x-dev).
 
 Required Python packages are listed in the [requirements.txt](requirements.txt)
 file in this repository. They can be installed with pip with the following

--- a/cmake/modules/PyTypeUtils.cmake
+++ b/cmake/modules/PyTypeUtils.cmake
@@ -1,21 +1,3 @@
-# Pytype's bison files can work with bison 3.0.4. However, we set the minimum
-# required version to 3.0.2 as that is the version of bison one can install
-# with apt-get on the Travis Trusty VMs.
-set(min_bison_version 3.0.2)
-find_package(BISON ${min_bison_version})
-if(NOT BISON_FOUND)
-  message(FATAL_ERROR "PyType requires 'bison'. The minimum required 'bison' version is ${min_bison_version}.")
-endif()
-
-# Pytype's flex files can work with flex 2.6.1. However, we set the minimum
-# required version to 2.5.35 as that is the version of flex one can install
-# with apt-get on the Travis Trusty VMs.
-set(min_flex_version 2.5.35)
-find_package(FLEX ${min_flex_version})
-if(NOT FLEX_FOUND)
-  message(FATAL_ERROR "PyType requires 'flex'. The minimum required 'flex' version is ${min_flex_version}.")
-endif()
-
 # Find the python interpreter first so that Python libs corresponding to the
 # version of this interpreter can be found below.
 find_package(PythonInterp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 # Python dependencies for building and testing the pytype source code.
 # Make sure you also install the non-Python dependencies described in
 # https://github.com/google/pytype/blob/master/CONTRIBUTING.md#pytype-dependencies.
-
-# see https://github.com/PyCQA/astroid/issues/1237, can be removed once pylint
-# requires this version.
-astroid>=2.8.5
-
 attrs>=21.2.0
 dataclasses; python_version < '3.7'
 importlab>=0.7


### PR DESCRIPTION
Noticed these issues while setting up a pytype dev environment on a new machine.

* Remove code that checked for the presence of bison and flex, which
  haven't been needed for a while.
* Note in CONTRIBUTING.md that the python3.x-dev package is also needed;
  I got a cryptic error from pybind11 when it was missing.
* Remove a line from requirements.txt that was previously needed to
  force installation of a newer version of astroid than pylint required.