### PR TITLE
Fix parameterized attributes for dataclass subclasses

### DIFF
--- a/pytype/abstract/class_mixin.py
+++ b/pytype/abstract/class_mixin.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Type
 
 from pytype import datatypes
 from pytype.abstract import abstract_utils
+from pytype.abstract import _classes
 from pytype.abstract import function
 from pytype.abstract import mixin  # pylint: disable=unused-import
 from pytype.pytd import mro
@@ -543,6 +544,21 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
           base_attrs.append(a)
     return base_attrs + cls_attrs
 
+  def _recompute_attrs_type_from_mro(self, all_attrs, type_params):
+    """Traverse the MRO and apply Generic type params to class attributes.
+
+    This IS REQUIRED for dataclass instances that inherits from a Generic.
+
+    Args:
+      all_attrs: All __init__ attributes of a class.
+      type_params: List of ParameterizedClass instances that will override
+        TypeVar attributes in all_attrs.
+    """
+    for typ_name, typ_obj in type_params.items():
+      for attr in all_attrs.values():
+        if typ_name == attr.typ.cls.name:
+          attr.typ = typ_obj
+
   def _get_attrs_from_mro(self, cls_attrs, metadata_key):
     """Traverse the MRO and collect base class attributes for metadata_key."""
 
@@ -552,6 +568,7 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
 
     all_attrs = {}
     sub_attrs = []
+    type_params = {}
     attributes_to_ignore = set()
     for base_cls in reversed(self.mro[1:]):
       if not isinstance(base_cls, Class):
@@ -559,6 +576,12 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
       # Some third-party dataclass implementations add implicit fields that
       # should not be considered inherited attributes.
       attributes_to_ignore.update(getattr(base_cls, "IMPLICIT_FIELDS", ()))
+      # Any subclass of a Parameterized dataclass must inherit attributes from
+      # its parent's init.
+      # See https://github.com/google/pytype/issues/1104
+      if isinstance(base_cls, _classes.ParameterizedClass):
+        type_params = base_cls._formal_type_parameters
+        base_cls = base_cls.base_cls
       if metadata_key in base_cls.metadata:
         sub_attrs.append([a for a in base_cls.metadata[metadata_key]
                           if a.name not in attributes_to_ignore])
@@ -566,6 +589,8 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
     for attrs in sub_attrs:
       for a in attrs:
         all_attrs[a.name] = a
+
+    self._recompute_attrs_type_from_mro(all_attrs, type_params)
     return list(all_attrs.values())
 
   def record_attr_ordering(self, own_attrs):

--- a/pytype/abstract/class_mixin.py
+++ b/pytype/abstract/class_mixin.py
@@ -578,7 +578,7 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
       # Any subclass of a Parameterized dataclass must inherit attributes from
       # its parent's init.
       # See https://github.com/google/pytype/issues/1104
-      if abstract_utils._isinstance(base_cls, "ParameterizedClass"):
+      if _isinstance(base_cls, "ParameterizedClass"):
         type_params = base_cls.formal_type_parameters
         base_cls = base_cls.base_cls
       if metadata_key in base_cls.metadata:
@@ -589,9 +589,7 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
       for a in attrs:
         all_attrs[a.name] = a
 
-    # type_params is only dict if it has been assigned in a dataclass context.
-    if isinstance(type_params, dict):
-        self._recompute_attrs_type_from_mro(all_attrs, type_params)
+    self._recompute_attrs_type_from_mro(all_attrs, type_params)
     return list(all_attrs.values())
 
   def record_attr_ordering(self, own_attrs):

--- a/pytype/abstract/class_mixin.py
+++ b/pytype/abstract/class_mixin.py
@@ -590,7 +590,9 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
       for a in attrs:
         all_attrs[a.name] = a
 
-    self._recompute_attrs_type_from_mro(all_attrs, type_params)
+    # type_params is only dict if it has been assigned in a dataclass context.
+    if isinstance(type_params, dict):
+        self._recompute_attrs_type_from_mro(all_attrs, type_params)
     return list(all_attrs.values())
 
   def record_attr_ordering(self, own_attrs):

--- a/pytype/abstract/class_mixin.py
+++ b/pytype/abstract/class_mixin.py
@@ -6,7 +6,6 @@ from typing import Any, List, Optional, Type
 
 from pytype import datatypes
 from pytype.abstract import abstract_utils
-from pytype.abstract import _classes
 from pytype.abstract import function
 from pytype.abstract import mixin  # pylint: disable=unused-import
 from pytype.pytd import mro
@@ -579,8 +578,8 @@ class Class(metaclass=mixin.MixinMeta):  # pylint: disable=undefined-variable
       # Any subclass of a Parameterized dataclass must inherit attributes from
       # its parent's init.
       # See https://github.com/google/pytype/issues/1104
-      if isinstance(base_cls, _classes.ParameterizedClass):
-        type_params = base_cls._formal_type_parameters
+      if abstract_utils._isinstance(base_cls, "ParameterizedClass"):
+        type_params = base_cls.formal_type_parameters
         base_cls = base_cls.base_cls
       if metadata_key in base_cls.metadata:
         sub_attrs.append([a for a in base_cls.metadata[metadata_key]


### PR DESCRIPTION
In subclasses of a Generic dataclass, the init method accepts the right
argument count, instead of expecting the argument number from its
parent's init method and raising a wrong-arg-count error.

Also add support for checking parameterized types of dataclass and raising
wrong-arg-types.

Fixes https://github.com/google/pytype/issues/1104