### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/developers/config.md
+++ b/docs/developers/config.md
@@ -184,7 +184,7 @@ copies options from the raw `input_options` to a final `output_options`. The
 3. Populate some options that do not correspond to inputs. For example
    `_store_python_version` sets both `output_options.python_version` and
    `output_options.python_exe`. The latter is derived from the python version
-   and cached in `options.python_exe`, but it can not be set indepedently.
+   and cached in `options.python_exe`, but it can not be set independently.
 
 
 ## Adding a new option

--- a/docs/developers/typegraph.md
+++ b/docs/developers/typegraph.md
@@ -225,7 +225,7 @@ When a `PyObject*` value is added to a Binding, it's transformed into a
 `BindingData` pointer with a cleanup function that decrements the reference
 count. This approach ensures that each `PyObject*` has a correct reference
 count, that no data objects will be deleted before the Binding is cleaned up,
-and that deleting a Binding (or a whole Program) will correctly decrememnt the
+and that deleting a Binding (or a whole Program) will correctly decrement the
 reference count. This avoids potential memory leaks caused by `PyObject`s not
 being cleaned up.
 


### PR DESCRIPTION
There are small typos in:
- docs/developers/config.md
- docs/developers/typegraph.md

Fixes:
- Should read `independently` rather than `indepedently`.
- Should read `decrement` rather than `decrememnt`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md