### PR TITLE
Fix a few very minor style issues.

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -17,8 +17,6 @@ jobs:
         
     runs-on: ${{ matrix.os }}
 
-    continue-on-error: ${{ matrix.experimental }}
-
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.9.1
@@ -37,6 +35,10 @@ jobs:
           
     - uses: ilammy/msvc-dev-cmd@v1
 
+    # We have to put continue-on-error at the step level rather than the job
+    # level because the UI is broken:
+    # https://github.com/github-community/community/discussions/15452.
+
     - name: Test
       run: | 
         set LIB=C:\Python\Libs;%LIB%
@@ -45,3 +47,4 @@ jobs:
         pip install -r requirements.txt
         python build_scripts/ci_script.py
       shell: cmd
+      continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -45,10 +44,16 @@ jobs:
     - name: Install Dependencies
       run: pip install -r requirements.txt
 
+    # We have to put continue-on-error at the step level rather than the job
+    # level because the UI is broken:
+    # https://github.com/github-community/community/discussions/15452.
+
     - name: Run Tests
       if: matrix.python-version != '3.11-dev'
       run: python build_scripts/ci_script.py
+      continue-on-error: ${{ matrix.experimental }}
 
     - name: Run Tests for python 3.11
       if: matrix.python-version == '3.11-dev'
-      run: python build_scripts/ci_script.py || exit 0
+      run: python build_scripts/ci_script.py
+      continue-on-error: ${{ matrix.experimental }}

--- a/pytype/context.py
+++ b/pytype/context.py
@@ -17,7 +17,6 @@ from pytype import tracer_vm
 from pytype import vm_utils
 from pytype.abstract import abstract
 from pytype.abstract import abstract_utils
-from pytype.abstract import class_mixin
 from pytype.abstract import function
 from pytype.typegraph import cfg
 from pytype.typegraph import cfg_utils
@@ -96,7 +95,7 @@ class Context:
     self.recursion_allowed = False
     # Map from classes to maps from names of the instance methods
     # of the class to their signatures.
-    self.method_signature_map: Dict[class_mixin.Class,
+    self.method_signature_map: Dict[abstract.Class,
                                     Dict[str, function.Signature]] = {}
 
   def matcher(self, node):

--- a/pytype/directors/parser.py
+++ b/pytype/directors/parser.py
@@ -69,7 +69,7 @@ class _SourceTree:
   structured_comments: Mapping[int, Sequence[_StructuredComment]]
 
 
-class BlockReturns:
+class _BlockReturns:
   """Tracks return statements in with/try blocks."""
 
   def __init__(self):
@@ -139,7 +139,7 @@ class _ParseVisitor(visitor.BaseVisitor):
     self.decorators = []
     self.defs_start = None
     self.function_ranges = {}
-    self.block_returns = BlockReturns()
+    self.block_returns = _BlockReturns()
     self.block_depth = 0
 
   def _add_structured_comment_group(self, start_line, end_line, cls=LineRange):

--- a/pytype/directors/parser_libcst.py
+++ b/pytype/directors/parser_libcst.py
@@ -56,7 +56,7 @@ class _VariableAnnotation(LineRange):
   annotation: str
 
 
-class BlockReturns:
+class _BlockReturns:
   """Tracks return statements in with/try blocks."""
 
   def __init__(self):
@@ -109,7 +109,7 @@ class _ParseVisitor(libcst.CSTVisitor):
     self.decorators = []
     self.defs_start = None
     self.function_ranges = {}
-    self.block_returns = BlockReturns()
+    self.block_returns = _BlockReturns()
 
   def _get_containing_groups(self, start_line, end_line=None):
     """Get _StructuredComment groups that fully contain the given line range."""

--- a/pytype/vm_utils.py
+++ b/pytype/vm_utils.py
@@ -115,6 +115,7 @@ class _NameErrorDetails(abc.ABC):
 class _NameInInnerClassErrorDetails(_NameErrorDetails):
 
   def __init__(self, attr, class_name):
+    super().__init__()
     self._attr = attr
     self._class_name = class_name
 


### PR DESCRIPTION
* Reorganize abstract_utils.py so that public classes and the special
  _isinstance and _make methods are at the top of the file.
* Use abstract.Class, not class_mixin.Class, to refer to Class in context.py.
* Make parser.BlockReturns private.
* Fix another 3.11 lint warning (missing super call) in vm_utils.py.

PiperOrigin-RevId: 461989284