### PR TITLE
Change Environment construction to prefer typeshed

### DIFF
--- a/pytype/tools/analyze_project/environment.py
+++ b/pytype/tools/analyze_project/environment.py
@@ -17,10 +17,10 @@ def create_importlab_environment(conf, typeshed):
   """Create an importlab environment from the python version and path."""
   python_version = utils.version_from_string(conf.python_version)
   path = fs.Path()
+  for p in typeshed.get_typeshed_paths():
+    path.add_path(p, 'pyi')
   for p in conf.pythonpath:
     path.add_path(p, 'os')
   for p in typeshed.get_pytd_paths():
     path.add_fs(PytdFileSystem(fs.OSFileSystem(p)))
-  for p in typeshed.get_typeshed_paths():
-    path.add_path(p, 'pyi')
   return environment.Environment(path, python_version)


### PR DESCRIPTION
Currently, typeshed only gets hit if nothing else does at an import parsing level in importlab. This dramatically increases the amount of time spent on standard library components in some situations. If we instead check typeshed first, we can aggressively take advantage of pre-created pyi files for typechecking performance.