### PR TITLE
add pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,12 @@
+- id: pytype
+  name: Pytype
+  description: A static type analyzer for Python code.
+  entry: pytype
+  # needs to run in the same virtual environment as the code being checked, therefore
+  # language = system instead of python
+  language: system
+  types: [python]
+  args:
+    - '--jobs=auto'
+    - '--keep-going'
+  files: \.py$


### PR DESCRIPTION
Closes #1300. Allows running pytype as a pre-commit hook. The caveat is, pytype still needs to be installed in the virtual environment where the type checks are being performed.

To test this from your python project:
```bash
pip install pre-commit pytype
pre-commit try-repo --verbose --all-files https://github.com/ilCatania/pytype.git
```
and you should get an output similar to this:
```
[INFO] Initializing environment for https://github.com/ilCatania/pytype.git.
===============================================================================
Using config:
===============================================================================
repos:
-   repo: https://github.com/ilCatania/pytype.git
    rev: 5a1228e8b277c3446c50fdc3767bd5057a886405
    hooks:
    -   id: pytype
===============================================================================
Pytype..................................................................Success
===============================================================================
```
