### PR TITLE
Remove [pytype] section from setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,20 +62,3 @@ console_scripts =
     pytype = pytype.tools.analyze_project.main:main
     pytype-single = pytype.single:main
     pyxref = pytype.tools.xref.main:main
-
-[pytype]
-inputs =
-    pytype/*.py
-    pytype/overlays/
-    pytype/pyc/
-    pytype/pyi/
-    pytype/pytd/
-    pytype/tools/
-    pytype/typegraph/
-    pytype_extensions/**/*.py
-exclude =
-    **/*_test.py
-    **/test_*.py
-    **/*_test_*.py
-    pytype/tools/merge_pyi/test_data/
-    pytype/tools/xref/testdata/


### PR DESCRIPTION
The same information is in pyproject.toml, which is supported as of version 2023.01.10.