### PR TITLE
Improve syntax highlighting of `.pytd` files on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Tell GitHub to use Python syntax highlighting for `.pytd` files
+*.pytd linguist-language=python


### PR DESCRIPTION
This PR teaches GitHub that `.pytd` files use Python syntax. This means that GitHub will apply much better syntax highlighting to `.pytd` files in pytype's source code.