### PR TITLE
Do not parse default values as types (#1350)

### DIFF
--- a/pytype/pyi/parser.py
+++ b/pytype/pyi/parser.py
@@ -129,6 +129,16 @@ def _attribute_to_name(node: ast3.Attribute) -> ast3.Name:
 class AnnotationVisitor(visitor.BaseVisitor):
   """Converts typed_ast annotations to pytd."""
 
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    # Exclude defaults because they may contain strings
+    # which should not be interpreted as annotations
+    self._node_children[self._ast.arguments] = [
+        field
+        for field in self._ast.arguments._fields
+        if field not in ("kw_defaults", "defaults")
+    ]
+
   def show(self, node):
     print(debug.dump(node, ast3, include_attributes=False))
 

--- a/pytype/pyi/parser_test.py
+++ b/pytype/pyi/parser_test.py
@@ -576,9 +576,9 @@ class QuotedTypeTest(parser_test_base.ParserTestBase):
 
   def test_def(self):
     self.check("""
-      def f(x: "int") -> "str": ...
+      def f(x: "int", *args: "float", y: "str", **kwargs: "bool") -> "str": ...
     """, """
-      def f(x: int) -> str: ...
+      def f(x: int, *args: float, y: str, **kwargs: bool) -> str: ...
     """)
 
 
@@ -845,6 +845,13 @@ class FunctionTest(parser_test_base.ParserTestBase):
     # Allow but do not preserve a trailing comma in the param list.
     self.check("def foo(x: int, y: str, z: bool,) -> int: ...",
                "def foo(x: int, y: str, z: bool) -> int: ...")
+
+  def test_defaults(self):
+    self.check("""
+      def f(x: int = 3, y: str = " ") -> None: ...
+    """, """
+      def f(x: int = ..., y: str = ...) -> None: ...
+    """)
 
   def test_star_params(self):
     self.check("def foo(*, x) -> str: ...")


### PR DESCRIPTION
See python/typeshed#9501.

Resolves #1350

PiperOrigin-RevId: 501717379