### PR TITLE
use ninja importability to determine python-ninja usability

### DIFF
--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -48,7 +48,7 @@ def _get_executable(binary, module=None):
               'pytype-single')
       ])
   importable = importlib.util.find_spec(module or binary)
-  if sys.executable is not None and importable is not None:
+  if sys.executable is not None and importable:
     return [sys.executable, '-m', module or binary]
   else:
     return [binary]

--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -1,5 +1,6 @@
 """Use pytype to analyze and infer types for an entire project."""
 
+import importlib
 import collections
 import itertools
 import logging
@@ -46,7 +47,8 @@ def _get_executable(binary, module=None):
               path_utils.abspath(path_utils.dirname(custom_bin)),
               'pytype-single')
       ])
-  if sys.executable is not None:
+  importable = importlib.util.find_spec(module or binary)
+  if sys.executable is not None and importable is not None:
     return [sys.executable, '-m', module or binary]
   else:
     return [binary]


### PR DESCRIPTION
Fixes https://github.com/google/pytype/issues/1376

There doesn't seem to be a need to force people to use python-ninja when the ninja binary is available. The logic is better now such that if python-ninja isn't available (importable), the command can fall back to ninja the binary.

xref:
- https://github.com/conda-forge/pytype-feedstock/pull/98
- https://github.com/conda-forge/staged-recipes/pull/19098

thanks to:
- @eli-schwartz
- @PythonCHB