### PR TITLE
Remove max Python version requirement from setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=3.8, <3.11
+python_requires = >=3.8
 packages =
     find:
 install_requires =


### PR DESCRIPTION
This prevents installation of very old versions of pytype when a newer version than supported is requested. Instead, the latest version of pytype will be installed, and it'll fail with a sensible error message about 3.xx not being supported yet.

Fixes https://github.com/google/pytype/issues/1481.