### PR TITLE
Do another PyPI release to get out an Unpack fix that typeshed needs.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Version 2023.12.08:
+
+Bug fixes:
+* Fix a crash with nested pattern matches.
+* Allow typing.Unpack to be parameterized.
+
 Version 2023.12.07:
 
 Updates:

--- a/pytype/__version__.py
+++ b/pytype/__version__.py
@@ -1,2 +1,2 @@
 # pylint: skip-file
-__version__ = '2023.12.07'
+__version__ = '2023.12.08'


### PR DESCRIPTION
For https://github.com/google/pytype/issues/1525.

PiperOrigin-RevId: 589185165