### PR TITLE
Support typing.Required and typing.NotRequired.

### DIFF
--- a/pytype/output.py
+++ b/pytype/output.py
@@ -1020,6 +1020,10 @@ class Converter(utils.ContextWeakrefMixin):
       typ = pytd_utils.JoinTypes(
           self.value_instance_to_pytd_type(node, p, None, set(), {})
           for p in var.data)
+      if v.props.total and k not in v.props.required:
+        typ = pytd.GenericType(pytd.NamedType("typing.NotRequired"), (typ,))
+      elif not v.props.total and k in v.props.required:
+        typ = pytd.GenericType(pytd.NamedType("typing.Required"), (typ,))
       constants.append(pytd.Constant(k, typ))
     return pytd.Class(name=name,
                       keywords=tuple(keywords),

--- a/pytype/overlays/CMakeLists.txt
+++ b/pytype/overlays/CMakeLists.txt
@@ -297,6 +297,7 @@ py_library(
     typed_dict.py
   DEPS
     .classgen
+    .overlay_utils
     pytype.abstract.abstract
     pytype.pytd.pytd
 )

--- a/pytype/overlays/overlay_utils.py
+++ b/pytype/overlays/overlay_utils.py
@@ -2,6 +2,7 @@
 
 from pytype.abstract import abstract
 from pytype.abstract import function
+from pytype.pytd import pep484
 from pytype.pytd import pytd
 from pytype.typegraph import cfg
 
@@ -37,6 +38,19 @@ class Param:
 
   def __repr__(self):
     return f"Param({self.name}, {self.typ!r}, {self.default!r})"
+
+
+class TypingContainer(abstract.AnnotationContainer):
+
+  def __init__(self, name, ctx):
+    if name in pep484.TYPING_TO_BUILTIN:
+      module = "builtins"
+      pytd_name = pep484.TYPING_TO_BUILTIN[name]
+    else:
+      module = "typing"
+      pytd_name = name
+    base = ctx.convert.lookup_value(module, pytd_name)
+    super().__init__(name, ctx, base)
 
 
 def make_method(ctx,

--- a/pytype/tests/test_typed_dict.py
+++ b/pytype/tests/test_typed_dict.py
@@ -954,8 +954,7 @@ class ItemRequirednessTest(test_base.BaseTest):
 
   def test_annotated(self):
     self.Check("""
-      from typing import Annotated
-      from typing_extensions import NotRequired, TypedDict
+      from typing_extensions import Annotated, NotRequired, TypedDict
       class X(TypedDict):
         k1: Annotated[NotRequired[str], 'HELLO']
         k2: NotRequired[Annotated[int, 'WORLD']]

--- a/pytype/tests/test_typed_dict.py
+++ b/pytype/tests/test_typed_dict.py
@@ -903,5 +903,122 @@ class IsTypedDictTest(test_base.BaseTest):
     """)
 
 
+class ItemRequirednessTest(test_base.BaseTest):
+  """Tests for typing.(Not)Required."""
+
+  def test_required(self):
+    self.CheckWithErrors("""
+      from typing_extensions import Required, TypedDict
+      class X(TypedDict, total=False):
+        k1: int
+        k2: Required[str]
+      x1: X = {'k2': 'ok'}
+      x2: X = {'k1': 1, 'k2': 'ok'}
+      x3: X = {'k1': 0}  # annotation-type-mismatch
+    """)
+
+  def test_not_required(self):
+    self.CheckWithErrors("""
+      from typing_extensions import NotRequired, TypedDict
+      class X(TypedDict):
+        k1: str
+        k2: NotRequired[int]
+      x1: X = {'k1': 'ok'}
+      x2: X = {'k1': 'ok', 'k2': 1}
+      x3: X = {'k2': 0}  # annotation-type-mismatch
+    """)
+
+  def test_malformed(self):
+    self.CheckWithErrors("""
+      from typing_extensions import NotRequired, Required, TypedDict
+      class X(TypedDict):
+        k1: Required[...]  # invalid-annotation
+        k2: NotRequired[...]  # invalid-annotation
+        k3: Required[int, str]  # invalid-annotation
+        k4: NotRequired[str, int]  # invalid-annotation
+        k5: Required[NotRequired[int]]  # invalid-annotation
+        k6: NotRequired[Required[str]]  # invalid-annotation
+    """)
+
+  @test_utils.skipBeforePy((3, 11), "typing.(Not)Required is new in 3.11.")
+  def test_typing_import(self):
+    self.CheckWithErrors("""
+      from typing import NotRequired, Required, TypedDict
+      class X(TypedDict, total=False):
+        k1: NotRequired[int]
+        k2: Required[str]
+      x1: X = {'k1': 1, 'k2': 'ok'}
+      x2: X = {'k2': 'ok'}
+      x3: X = {'k1': 0}  # annotation-type-mismatch
+    """)
+
+  def test_annotated(self):
+    self.Check("""
+      from typing import Annotated
+      from typing_extensions import NotRequired, TypedDict
+      class X(TypedDict):
+        k1: Annotated[NotRequired[str], 'HELLO']
+        k2: NotRequired[Annotated[int, 'WORLD']]
+      x1: X = {'k1': 'ok', 'k2': 1}
+      x2: X = {'k1': 'ok'}
+      x3: X = {'k2': 1}
+      x4: X = {}
+    """)
+
+  def test_unparameterized(self):
+    self.CheckWithErrors("""
+      from typing_extensions import Required, TypedDict
+      class X(TypedDict, total=False):
+        k1: Required  # treated as Required[Any]
+      class Anything:
+        pass
+      x1: X = {'k1': Anything()}
+      x2: X = {}  # annotation-type-mismatch
+    """)
+
+  def test_functional_syntax(self):
+    self.CheckWithErrors("""
+      from typing_extensions import NotRequired, Required, TypedDict
+      X = TypedDict('X', {'k1': Required[str], 'k2': NotRequired[int]})
+      x1: X = {'k1': 'ok'}
+      x2: X = {'k1': 'ok', 'k2': 1}
+      x3: X = {'k2': 0}  # annotation-type-mismatch
+    """)
+
+  def test_pyi(self):
+    with self.DepTree([("foo.pyi", """
+      from typing import NotRequired, Required, TypedDict
+      class X(TypedDict):
+        k1: Required[str]
+        k2: NotRequired[int]
+    """)]):
+      self.CheckWithErrors("""
+        import foo
+        x1: foo.X = {'k1': 'ok'}
+        x2: foo.X = {'k1': 'ok', 'k2': 1}
+        x3: foo.X = {'k2': 0}  # annotation-type-mismatch
+      """)
+
+  def test_output(self):
+    ty = self.Infer("""
+      from typing_extensions import NotRequired, Required, TypedDict
+      class X1(TypedDict):
+        k1: Required[str]
+        k2: NotRequired[int]
+      class X2(TypedDict, total=False):
+        k1: Required[str]
+        k2: NotRequired[int]
+    """)
+    self.assertTypesMatchPytd(ty, """
+      from typing import NotRequired, Required, TypedDict
+      class X1(TypedDict):
+        k1: str
+        k2: NotRequired[int]
+      class X2(TypedDict, total=False):
+        k1: Required[str]
+        k2: int
+    """)
+
+
 if __name__ == "__main__":
   test_base.main()


### PR DESCRIPTION
Fixes https://github.com/google/pytype/issues/1551.

PiperOrigin-RevId: 592386426