### PR TITLE
minor clean-up to remove mentions of pytype.single

### DIFF
--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -52,7 +52,7 @@ def _get_executable(binary, module=None):
     return [sys.executable, '-m', module or binary]
   else:
     return [binary]
-PYTYPE_SINGLE = _get_executable('pytype-single', 'pytype.single')
+PYTYPE_SINGLE = _get_executable('pytype-single', 'pytype.main')
 
 
 def resolved_file_to_module(f):

--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -52,7 +52,7 @@ def _get_executable(binary, module=None):
     return [sys.executable, '-m', module or binary]
   else:
     return [binary]
-PYTYPE_SINGLE = _get_executable('pytype-single', 'pytype.main')
+PYTYPE_SINGLE = _get_executable('pytype-single')
 
 
 def resolved_file_to_module(f):


### PR DESCRIPTION
In `_get_executable('pytype-single', 'pytype.single')`, the module part (`pytype.single`) wasn't used in the logic above (see below). So, to avoid confusion, just delete it altogether.


```py
  if binary == 'pytype-single':
    custom_bin = path_utils.join('out', 'bin', 'pytype')
    if sys.argv[0] == custom_bin:
      # The Travis type-check step uses custom binaries in pytype/out/bin/.
      return (([] if sys.platform != 'win32' else [sys.executable]) + [
          path_utils.join(
              path_utils.abspath(path_utils.dirname(custom_bin)),
              'pytype-single')
      ])
```