### PR TITLE
Add 'default' field to pytd.TypeParameter.

### DIFF
--- a/pytype/pyi/definitions.py
+++ b/pytype/pyi/definitions.py
@@ -468,11 +468,13 @@ class Definitions:
       raise _ParseError(f"{tvar.kind} name needs to be {tvar.name!r} "
                         f"(not {name!r})")
     bound = tvar.bound
-    if isinstance(bound, str):
-      bound = pytd.NamedType(bound)
     constraints = tuple(tvar.constraints) if tvar.constraints else ()
+    if isinstance(tvar.default, list):
+      default = tuple(tvar.default)
+    else:
+      default = tvar.default
     self.type_params.append(pytd_type(
-        name=name, constraints=constraints, bound=bound))
+        name=name, constraints=constraints, bound=bound, default=default))
 
   def add_import(self, from_package, import_list):
     """Add an import.

--- a/pytype/pyi/parser_test.py
+++ b/pytype/pyi/parser_test.py
@@ -3526,5 +3526,30 @@ class UnpackTest(parser_test_base.ParserTestBase):
     """)
 
 
+class TypeParameterDefaultTest(parser_test_base.ParserTestBase):
+
+  def test_typevar(self):
+    self.check("""
+      from typing_extensions import TypeVar
+
+      T = TypeVar('T', default=int)
+    """)
+
+  def test_paramspec(self):
+    self.check("""
+      from typing_extensions import ParamSpec
+
+      P = ParamSpec('P', default=[str, int])
+    """)
+
+  def test_typevartuple(self):
+    self.check("""
+      from typing_extensions import TypeVarTuple, Unpack
+      Ts = TypeVarTuple('Ts', default=Unpack[tuple[str, int]])
+    """, """
+      from typing_extensions import TypeVarTuple, TypeVarTuple as Ts, Unpack
+    """)
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/pytype/pytd/printer.py
+++ b/pytype/pytd/printer.py
@@ -209,6 +209,11 @@ class PrintVisitor(base_visitor.Visitor):
       args += [self.Print(c) for c in t.constraints]
       if t.bound:
         args.append(f"bound={self.Print(t.bound)}")
+      if isinstance(t.default, tuple):
+        args.append(
+            f"default=[{', '.join(self.Print(d) for d in t.default)}]")
+      elif t.default:
+        args.append(f"default={self.Print(t.default)}")
       if isinstance(t, pytd.ParamSpec):
         typename = self._LookupTypingMember("ParamSpec")
       else:

--- a/pytype/pytd/pytd.py
+++ b/pytype/pytd/pytd.py
@@ -344,6 +344,7 @@ class TypeParameter(Type):
   name: str
   constraints: Tuple[TypeU, ...] = ()
   bound: Optional[TypeU] = None
+  default: Optional[Union[TypeU, Tuple[TypeU, ...]]] = None
   scope: Optional[str] = None
 
   def __lt__(self, other):

--- a/pytype/pytd/visitors_test.py
+++ b/pytype/pytd/visitors_test.py
@@ -552,8 +552,7 @@ class TestVisitors(parser_test_base.ParserTest):
     """)
     a = ast.Lookup("A")
     self.assertEqual(
-        (pytd.TemplateItem(pytd.TypeParameter("T", (), None, "A")),),
-        a.template)
+        (pytd.TemplateItem(pytd.TypeParameter("T", scope="A")),), a.template)
 
   def test_adjust_type_parameters_with_duplicates_in_generic(self):
     src = textwrap.dedent("""


### PR DESCRIPTION
I did a few manual checks, and I believe this can be submitted without a corresponding release without breaking anything. We might as well give it a try and see how it goes.

For https://github.com/google/pytype/issues/1597.

PiperOrigin-RevId: 617071069