### PR TITLE
Update pytype_runner.py - change escape_ninja_path to escape all the ninja path escape-needing characters

### DIFF
--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -146,12 +146,17 @@ def _module_to_output_path(mod):
 
 
 def escape_ninja_path(path: str):
-  """escape colon, dollar sign, space, and new line, for ninja
-  ( as described in https://ninja-build.org/manual.html#ref_lexer );
-  thus, this function should only ever be used once,
-  called on a path string to turn it into a ninja path string
-  (if you call it on a ninja path string, it will render the variables inert)
-  in order to allow for path strings that contain these four characters"""
+  """Returns the path with special characters escaped.
+
+  Escape colon, dollar sign, space, and new line, for ninja
+  (as described in https://ninja-build.org/manual.html#ref_lexer).
+  This function should only ever be used once, called on a path string to turn
+  it into a ninja path string. (If you call it on a ninja path string, it will
+  render the variables inert.)
+
+  Args:
+    path: The path.
+  """
   new_path = ''
   for ch in path:
     if ch == ':':

--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -151,7 +151,7 @@ def escape_ninja_path(path: str):
 
   Escape new line, space, colon, and dollar sign, for ninja
   (as described in https://ninja-build.org/manual.html#ref_lexer).
-  This function should only ever be used once, called on a path string to turn
+  This function should be called on an unescaped path string to turn
   it into a ninja path string. (If you call it on a ninja path string, it will
   render the ninja variables inert.)
 

--- a/pytype/tools/analyze_project/pytype_runner_test.py
+++ b/pytype/tools/analyze_project/pytype_runner_test.py
@@ -3,7 +3,6 @@
 import collections
 import dataclasses
 import re
-import sys
 from typing import Sequence
 
 from pytype import config as pytype_config

--- a/pytype/tools/analyze_project/pytype_runner_test.py
+++ b/pytype/tools/analyze_project/pytype_runner_test.py
@@ -629,7 +629,7 @@ class TestNinjaBody(TestBase):
             output=path_utils.join(runner.pyi_dir, 'foo.pyi'),
             action=Action.CHECK,
             input='foo.py',
-            deps=deps=[path_utils.join(runner.pyi_dir, 'bar.pyi')],
+            deps=[path_utils.join(runner.pyi_dir, 'bar.pyi')],
             imports=path_utils.join(runner.imports_dir, 'foo.imports'),
             module='foo'))
 


### PR DESCRIPTION
This fixes https://github.com/google/pytype/issues/499

Unfortunately, I was not able to get pytype running on my machine, so this commit is just based on what seems like the right idea to me, and hopefully it can be verified to be correct by a maintainer and then merged.