### PR TITLE
merge_files should overwrite the existing annotations

### DIFF
--- a/pytype/tools/merge_pyi/merge_pyi.py
+++ b/pytype/tools/merge_pyi/merge_pyi.py
@@ -23,6 +23,7 @@ def _merge_csts(*, py_tree, pyi_tree):
   vis.store_stub_in_context(context, pyi_tree)
   return vis(
       context,
+      overwrite_existing_annotations=True,
       strict_posargs_matching=False,
       strict_annotation_matching=True,
   ).transform_module(py_tree)

--- a/pytype/tools/merge_pyi/test_data/defaults.pep484.py
+++ b/pytype/tools/merge_pyi/test_data/defaults.pep484.py
@@ -26,7 +26,7 @@ def f6(x:e6=int) -> r6:
     pass
 
 # static analysis would give error here
-def f7(x : int=int):
+def f7(x:e7=int) -> r7:
     pass
 
 def f8(x:e8={1:2}) -> r8:

--- a/pytype/tools/merge_pyi/test_data/partial.pep484.py
+++ b/pytype/tools/merge_pyi/test_data/partial.pep484.py
@@ -1,7 +1,7 @@
-def f1(a, b : int):
+def f1(a: e1, b: e2) -> r1:
     pass
 
-def f2(a, b) -> int:
+def f2(a: e1, b: e2) -> r2:
     pass
 
 def f3(a) -> r3:


### PR DESCRIPTION
Hi, PyType Team,

During my experiments with PyType, I found some instances of the following issue:

python code (minimal) to check:
```python
    def __init__(self, args: list[str]):
        pass
```

Running PyType on it and get the pyi output file:
```python
    def __init__(self, args: List[str]) -> None: ...
```

Running merge_file:

Expected output:
```python
    def __init__(self, args: List[str]) -> None:
        pass
```

Actual output:
```python
    def __init__(self, args: list[str]):
        pass
```

This problem is caused by libcst.codemod.visitors.ApplyTypeAnnotationsVisitor treats function annotations as a whole annotation. Thus, by PyType's default setting, the code to check already has (list[str]) as the annotation, which is different than the List[str] in the output file, and merge_files will not overwrite it.

However, the expected usage of merge_files is to merge the pyi output file generated by PyType back to the checked python file. In cases of the above issue, it fails to achieve its object and may cause the merged file to lose some generated annotations.

Also, because the pyi files are generated by running PyType, the only possible changes from the annotations in the original Python file to the annotations in the pyi file are cases like list[] to List[]. Thus, it should be safe to overwrite the original Python file.