### PR TITLE
build.yml “Don't run this on every push ('on' param)”

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,11 @@
 # Outstanding TODOs:
 # - Auto PyPI upload?
 # - Build sdist here too while we're at it?
-# - Don't run this on every push ('on' param)
 
 name: Build wheels
 on:
-  push:
-    branches: [ main ]
+  # `on: create` "Runs your workflow when someone creates a Git reference (Git branch or tag) in the workflow's repository. Note: An event will not be created when you create more than three tags at once."  -- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#create . See also: https://github.com/actions/runner/issues/1007
+  create: # The purpose of this line is to run only when we create a release, which is a tag. I'm assuming these are created in github somehow; if that assumption isn't true, we may need to use on: push: tags instead, cf https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
   pull_request:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
The purpose of this line is to run (ie, build wheels) only when we create a release, which is a tag. I'm assuming these release tags are created in github somehow; if that assumption isn't true, we may need to use `on: push: tags` instead.

In my own manual testing, this definitely prevented `Build wheels` from running on every push. Whether it also allows `Build wheels` to run at the right times is a little less certain, and depends on how this project is run. It runs `Build wheels` when I create a new tag in github! It also runs `Build wheels` when I create a new branch in github, but I don't think there's any way to prevent that; but that seems harmless enough.