### PR TITLE
Ensure python 3.12 support for pylint by requiring pylint >=3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ninja>=1.10.0.post2
 pybind11>=2.10.1
 pycnite>=2024.07.31
 pydot>=1.4.2
-pylint>=3.0.0,!=3.2.4 # Python 3.12 support was officially introduced in pylint 3.0.0 (Python 3.7 support, which we don't need, was officially dropped) https://pylint.pycqa.org/en/stable/whatsnew/3/3.0/index.html  # 3.2.4 was a bad version I guess: https://github.com/pylint-dev/pylint/issues/9751
+pylint>=3.0.0,!=3.2.4  # https://github.com/pylint-dev/pylint/issues/9751
 tabulate>=0.8.10
 toml>=0.10.2
 typing-extensions>=4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ninja>=1.10.0.post2
 pybind11>=2.10.1
 pycnite>=2024.07.31
 pydot>=1.4.2
-pylint>=3.0.0,!=3.2.4 # Python 3.12 support was officially introduced in pylint 3.0.0 (Python 3.7 support, which we don't need, was officially dropped) https://pylint.pycqa.org/en/stable/whatsnew/3/3.0/  # 3.2.4 was a bad version I guess: https://github.com/pylint-dev/pylint/issues/9751
+pylint>=3.0.0,!=3.2.4 # Python 3.12 support was officially introduced in pylint 3.0.0 (Python 3.7 support, which we don't need, was officially dropped) https://pylint.pycqa.org/en/stable/whatsnew/3/3.0/index.html  # 3.2.4 was a bad version I guess: https://github.com/pylint-dev/pylint/issues/9751
 tabulate>=0.8.10
 toml>=0.10.2
 typing-extensions>=4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ninja>=1.10.0.post2
 pybind11>=2.10.1
 pycnite>=2024.07.31
 pydot>=1.4.2
-pylint>=2.14.4,<3.2.4  # https://github.com/pylint-dev/pylint/issues/9751
+pylint>=3.0.0,!=3.2.4 # Python 3.12 support was officially introduced in pylint 3.0.0 (Python 3.7 support, which we don't need, was officially dropped)  # 3.2.4 was a bad version I guess: https://github.com/pylint-dev/pylint/issues/9751
 tabulate>=0.8.10
 toml>=0.10.2
 typing-extensions>=4.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ ninja>=1.10.0.post2
 pybind11>=2.10.1
 pycnite>=2024.07.31
 pydot>=1.4.2
-pylint>=3.0.0,!=3.2.4 # Python 3.12 support was officially introduced in pylint 3.0.0 (Python 3.7 support, which we don't need, was officially dropped)  # 3.2.4 was a bad version I guess: https://github.com/pylint-dev/pylint/issues/9751
+pylint>=3.0.0,!=3.2.4 # Python 3.12 support was officially introduced in pylint 3.0.0 (Python 3.7 support, which we don't need, was officially dropped) https://pylint.pycqa.org/en/stable/whatsnew/3/3.0/  # 3.2.4 was a bad version I guess: https://github.com/pylint-dev/pylint/issues/9751
 tabulate>=0.8.10
 toml>=0.10.2
 typing-extensions>=4.3.0


### PR DESCRIPTION
Python 3.12 support was officially introduced in pylint 3.0.0 (Python 3.7 support, which we don't need, was officially dropped) https://pylint.pycqa.org/en/stable/whatsnew/3/3.0/index.html