### PR TITLE
Update required version for typing-extensions.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,4 +15,4 @@ pydot>=1.4.2
 pylint>=3.0.0,!=3.2.4  # https://github.com/pylint-dev/pylint/issues/9751
 tabulate>=0.8.10
 toml>=0.10.2
-typing-extensions>=4.3.0
+typing-extensions>=4.4.0


### PR DESCRIPTION
Pytype uses typing_extensions.override,
cf. https://github.com/google/pytype/blob/83e28a715021d9cbd442ce4e2b33965212d58028/pytype/pyc/opcodes.py#L8, but that requires typing_extensions 4.4.0,
cf. https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.override.