### PR TITLE
add _Final class to typing module stubs

### DIFF
--- a/pytype/stubs/builtins/typing.pytd
+++ b/pytype/stubs/builtins/typing.pytd
@@ -29,7 +29,7 @@ _V4 = TypeVar('_V4')
 
 
 Text = str
-
+class _Final: ...
 
 # These functions do not exist in typing.py. They are here for documentation
 # purposes and to make it easier for pytype to type-check arguments to TypeVar


### PR DESCRIPTION
I recently put up an MR for typeshed that attempts to add various typing module internal base classes. The pipeline failed on pytype because of the lack of `typing._Final` in pytype's stubs.

typeshed MR: https://github.com/python/typeshed/pull/13011

I'm not sure that that MR will be accepted due to how complicated it is, but if it isn't then I'll probably consider a simpler version that only adds `typing._Final` - that part appears to clean up a few mypy errors for pydantic. So this is potentially useful either way.