### PR TITLE
feat: Export errors to csv file formats

### DIFF
--- a/pytype/file_utils.py
+++ b/pytype/file_utils.py
@@ -158,7 +158,7 @@ def is_file_script(filename, directory=None):
       except UnicodeDecodeError:
         return False
       return re.fullmatch(r"#!.+python3?", line) is not None
-    
+
 
 def merge_csvs(output: str, files: typing.List[str]) -> None:
   """Merge contents of csv into one output csv file."""

--- a/pytype/file_utils.py
+++ b/pytype/file_utils.py
@@ -5,6 +5,7 @@ import errno
 import os
 import re
 import sys
+import typing
 
 from pytype.platform_utils import path_utils
 
@@ -157,3 +158,12 @@ def is_file_script(filename, directory=None):
       except UnicodeDecodeError:
         return False
       return re.fullmatch(r"#!.+python3?", line) is not None
+    
+
+def merge_csvs(output: str, files: typing.List[str]) -> None:
+  """Merge contents of csv into one output csv file."""
+  with open(output, "w") as f:
+    for file in files:
+      with open(file, "r") as ifile:
+        f.write(ifile.read())
+      os.remove(file)

--- a/pytype/file_utils_test.py
+++ b/pytype/file_utils_test.py
@@ -308,16 +308,13 @@ class TestMergeCSVFiles(unittest.TestCase):
     with test_utils.Tempdir() as d:
       p1 = d.create_file("a.csv", "a,b,c\n1,2,3\n4,5,6\n")
       p2 = d.create_file("b.csv", "a,b,c\n7,8,9\n10,11,12\n")
-
       m = d.create_file("merged.csv")
-      
       file_utils.merge_csvs(m, [p1, p2])
       with open(m) as f:
         self.assertEqual(
           f.read(),
           "a,b,c\n1,2,3\n4,5,6\na,b,c\n7,8,9\n10,11,12\n"
         )
-
       self.assertFalse(path_utils.isfile(p1))
       self.assertFalse(path_utils.isfile(p2))
 

--- a/pytype/file_utils_test.py
+++ b/pytype/file_utils_test.py
@@ -309,7 +309,7 @@ class TestMergeCSVFiles(unittest.TestCase):
       d.create_file("a.csv", "a,b,c\n1,2,3\n4,5,6")
       d.create_file("b.csv", "a,b,c\n7,8,9\n10,11,12")
       
-      file_utils.merge_csv(
+      file_utils.merge_csvs(
         "merged.csv",
         ["a.csv", "b.csv"],
       )

--- a/pytype/file_utils_test.py
+++ b/pytype/file_utils_test.py
@@ -302,5 +302,27 @@ class TestExpandGlobpaths(unittest.TestCase):
       )
 
 
+class TestMergeCSVFiles(unittest.TestCase):
+
+  def test_merge(self):
+    with test_utils.Tempdir() as d:
+      d.create_file("a.csv", "a,b,c\n1,2,3\n4,5,6")
+      d.create_file("b.csv", "a,b,c\n7,8,9\n10,11,12")
+      
+      file_utils.merge_csv(
+        "merged.csv",
+        ["a.csv", "b.csv"],
+      )
+      with open("merged.csv") as f:
+        self.assertEqual(
+          f.read(),
+          "a,b,c\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n"
+        )
+
+      self.assertFalse(path_utils.isfile("a.csv"))
+      self.assertFalse(path_utils.isfile("b.csv"))
+
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/pytype/file_utils_test.py
+++ b/pytype/file_utils_test.py
@@ -306,22 +306,20 @@ class TestMergeCSVFiles(unittest.TestCase):
 
   def test_merge(self):
     with test_utils.Tempdir() as d:
-      d.create_file("a.csv", "a,b,c\n1,2,3\n4,5,6")
-      d.create_file("b.csv", "a,b,c\n7,8,9\n10,11,12")
+      p1 = d.create_file("a.csv", "a,b,c\n1,2,3\n4,5,6\n")
+      p2 = d.create_file("b.csv", "a,b,c\n7,8,9\n10,11,12\n")
+
+      m = d.create_file("merged.csv")
       
-      file_utils.merge_csvs(
-        "merged.csv",
-        ["a.csv", "b.csv"],
-      )
-      with open("merged.csv") as f:
+      file_utils.merge_csvs(m, [p1, p2])
+      with open(m) as f:
         self.assertEqual(
           f.read(),
-          "a,b,c\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n"
+          "a,b,c\n1,2,3\n4,5,6\na,b,c\n7,8,9\n10,11,12\n"
         )
 
-      self.assertFalse(path_utils.isfile("a.csv"))
-      self.assertFalse(path_utils.isfile("b.csv"))
-
+      self.assertFalse(path_utils.isfile(p1))
+      self.assertFalse(path_utils.isfile(p2))
 
 
 if __name__ == "__main__":

--- a/pytype/tools/analyze_project/config.py
+++ b/pytype/tools/analyze_project/config.py
@@ -7,9 +7,9 @@ import logging
 import os
 import sys
 import textwrap
-from typing import Any
+from typing import Any, Optional
 
-from pytype import config as pytype_config
+from pytype import config as pytype_config, datatypes
 from pytype import file_utils
 from pytype import utils
 from pytype.platform_utils import path_utils
@@ -85,11 +85,21 @@ REPORT_ERRORS_ITEMS = {
 }
 
 
+def _get_pytype_flag(flag: str) -> Optional[pytype_config._Arg]:
+  return next((arg for arg in pytype_config.ALL_OPTIONS if arg.flag == flag), None)
+
+
+CUSTOM_FLAGS = list(filter(None, [
+    _get_pytype_flag('output-errors-csv'),
+]))
+
+
 # The missing fields will be filled in by generate_sample_config_or_die.
 def _pytype_single_items():
   """Args to pass through to pytype_single."""
   out = {}
-  flags = pytype_config.FEATURE_FLAGS + pytype_config.EXPERIMENTAL_FLAGS
+  flags = pytype_config.FEATURE_FLAGS + pytype_config.EXPERIMENTAL_FLAGS + CUSTOM_FLAGS
+
   for arg in flags:
     opt = arg.args[0]
     dest = arg.get('dest')
@@ -289,3 +299,7 @@ def read_config_file_or_die(filepath):
     else:
       logging.info('No config file found. Using default configuration.')
   return ret
+
+
+def add_custom_flags(o: datatypes.ParserWrapper):
+  pytype_config.add_options(o, CUSTOM_FLAGS)

--- a/pytype/tools/analyze_project/parse_args.py
+++ b/pytype/tools/analyze_project/parse_args.py
@@ -36,13 +36,9 @@ class Parser:
     self.pytype_single_args = pytype_single_args
     self._pytype_arg_map = pytype_config.args_map()
 
-  # Populate initially with defaults, then overwrite with file-configurable.
-  # Ex: output_errors_csv depends on report_errors, which is set by a default (store_false).
   def create_initial_args(self, keys):
     """Creates the initial set of args."""
-    defaults = self._parser.parse_args([])
-    self.clean_args(defaults, keys)
-    return defaults
+    return argparse.Namespace(**{k: None for k in keys})
 
   def config_from_defaults(self):
     defaults = self._parser.parse_args([])
@@ -81,6 +77,8 @@ class Parser:
     args = self.create_initial_args(file_config_names)
     self._parser.parse_args(argv, args)
     self.clean_args(args, file_config_names)
+    # output_errors_csv is dependent on report_errors, so we set it here.
+    args.report_errors = getattr(args, 'output_errors_csv', None) or getattr(args, 'report_errors', True)
     self.postprocess(args)
     return args
 

--- a/pytype/tools/analyze_project/parse_args.py
+++ b/pytype/tools/analyze_project/parse_args.py
@@ -78,7 +78,7 @@ class Parser:
     self._parser.parse_args(argv, args)
     self.clean_args(args, file_config_names)
     # output_errors_csv is dependent on report_errors, so we set it here.
-    args.report_errors = getattr(args, 'output_errors_csv', None) or getattr(args, 'report_errors', True)
+    args.report_errors = hasattr(args, 'output_errors_csv') or getattr(args, 'report_errors', True)
     self.postprocess(args)
     return args
 

--- a/pytype/tools/analyze_project/parse_args.py
+++ b/pytype/tools/analyze_project/parse_args.py
@@ -36,9 +36,13 @@ class Parser:
     self.pytype_single_args = pytype_single_args
     self._pytype_arg_map = pytype_config.args_map()
 
+  # Populate initially with defaults, then overwrite with file-configurable.
+  # Ex: output_errors_csv depends on report_errors, which is set by a default (store_false).
   def create_initial_args(self, keys):
     """Creates the initial set of args."""
-    return argparse.Namespace(**{k: None for k in keys})
+    defaults = self._parser.parse_args([])
+    self.clean_args(defaults, keys)
+    return defaults
 
   def config_from_defaults(self):
     defaults = self._parser.parse_args([])
@@ -157,6 +161,7 @@ def make_parser():
   wrapper = datatypes.ParserWrapper(parser)
   pytype_config.add_basic_options(wrapper)
   pytype_config.add_feature_flags(wrapper)
+  config.add_custom_flags(wrapper)
   return Parser(parser, pytype_single_args=wrapper.actions)
 
 

--- a/pytype/tools/analyze_project/parse_args_test.py
+++ b/pytype/tools/analyze_project/parse_args_test.py
@@ -42,7 +42,7 @@ class TestParser(unittest.TestCase):
 
   def test_parse_no_filename(self):
     args = self.parser.parse_args([])
-    self.assertFalse(hasattr(args, 'inputs'))
+    self.assertEqual(args.inputs, set())
 
   def test_parse_bad_filename(self):
     args = self.parser.parse_args(['this_file_should_not_exist'])
@@ -147,8 +147,9 @@ class TestParser(unittest.TestCase):
 
   def test_defaults(self):
     args = self.parser.parse_args([])
-    for arg in config.ITEMS:
-      self.assertFalse(hasattr(args, arg))
+    defaults = self.parser.config_from_defaults()
+    for key in config.ITEMS:
+      self.assertEqual(getattr(args, key), getattr(defaults, key))
 
   def test_pytype_single_args(self):
     args = self.parser.parse_args(['--disable=import-error'])

--- a/pytype/tools/analyze_project/parse_args_test.py
+++ b/pytype/tools/analyze_project/parse_args_test.py
@@ -42,7 +42,7 @@ class TestParser(unittest.TestCase):
 
   def test_parse_no_filename(self):
     args = self.parser.parse_args([])
-    self.assertEqual(args.inputs, set())
+    self.assertFalse(hasattr(args, 'inputs'))
 
   def test_parse_bad_filename(self):
     args = self.parser.parse_args(['this_file_should_not_exist'])
@@ -147,10 +147,9 @@ class TestParser(unittest.TestCase):
 
   def test_defaults(self):
     args = self.parser.parse_args([])
-    defaults = self.parser.config_from_defaults()
-    for key in config.ITEMS:
-      self.assertEqual(getattr(args, key), getattr(defaults, key))
-
+    for arg in config.ITEMS:
+      self.assertFalse(hasattr(args, arg))
+      
   def test_pytype_single_args(self):
     args = self.parser.parse_args(['--disable=import-error'])
     self.assertSequenceEqual(args.disable, ['import-error'])

--- a/pytype/tools/analyze_project/parse_args_test.py
+++ b/pytype/tools/analyze_project/parse_args_test.py
@@ -149,7 +149,7 @@ class TestParser(unittest.TestCase):
     args = self.parser.parse_args([])
     for arg in config.ITEMS:
       self.assertFalse(hasattr(args, arg))
-      
+
   def test_pytype_single_args(self):
     args = self.parser.parse_args(['--disable=import-error'])
     self.assertSequenceEqual(args.disable, ['import-error'])

--- a/pytype/tools/analyze_project/pytype_runner.py
+++ b/pytype/tools/analyze_project/pytype_runner.py
@@ -232,7 +232,7 @@ class PytypeRunner:
 
     if self.output_errors_csv:
       flags_with_values['--output-errors-csv'] = '$out_path'
-      
+
     # Order the flags so that ninja recognizes commands across runs.
     return (
         exe +


### PR DESCRIPTION
Resolves issue #92 , exposing the `output-errors-csv` flag to the analyze_project tool. Creates csv exports on a per file basis using ninja + pytype runner in subprocess's and finally accumulated into one csv file after analysis.

@martindemello @h-joo take a look whenever you guys are free 😄 